### PR TITLE
Remove relative URLs from all anchor tags  

### DIFF
--- a/pages/reference.html
+++ b/pages/reference.html
@@ -1,408 +1,719 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="utf-8">
+  <head>
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Array.prototype.forEach() - JavaScript | MDN</title>
     <link rel="stylesheet" href="./css/mdn-minimalist.css" media="screen" />
-</head>
+  </head>
 
-<body data-gr-c-s-loaded="true">
+  <body data-gr-c-s-loaded="true">
     <div id="react-container" data-component-name="SPA">
-        <div class="loading-bar"></div>
-        <ul id="nav-access">
-            <li><a id="skip-main" href="#content">Skip to main content</a></li>
-            <li><a id="skip-language" href="#language">Select language</a></li>
-            <li><a id="skip-search" href="#main-q">Skip to search</a></li>
-        </ul>
-        <header class="page-header"><a href="/en-US/" class="logo" aria-label="MDN Web Docs"><svg
-                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 219 48" role="img">
-                    <path
-                        d="M49.752 30.824h59.917v17.132H49.75zm57.23 12.3c-.103.03-.21.048-.316.05-.338 0-.514-.15-.514-.582v-3.256c0-1.71-1.352-2.543-2.976-2.543a7.206 7.206 0 0 0-3.21.676l-.29 1.724 1.71.182.245-.842a2.338 2.338 0 0 1 1.147-.216c1.214 0 1.23.913 1.23 1.69v.234c-.407-.048-.818-.07-1.23-.068-1.71 0-3.49.433-3.49 2.276 0 1.563 1.23 2.144 2.31 2.144a2.7 2.7 0 0 0 2.41-1.494c.018.88.77 1.563 1.648 1.494a2.89 2.89 0 0 0 1.353-.338zm-4.604-.05a.787.787 0 0 1-.88-.867c0-.815.677-1.015 1.432-1.015.36.008.722.04 1.078.098-.05 1.235-.852 1.783-1.63 1.783zM97.388 33l-3.24 11.433h2.11L99.5 33.002zm-4.353 0l-3.24 11.433h2.11L95.145 33zm-6.89 6.645h2.243V36.94h-2.242zm0 4.802h2.243v-2.706h-2.242zm-3.617-1.64H80.1l4.156-4.736-.166-1.13h-6.58l-.268 2.63 1.546.164.338-1.163h2.343l-4.123 4.734.216 1.13h6.544l.467-2.63-1.69-.164zM72.143 36.79c-2.706 0-4.02 1.812-4.02 4.004 0 2.394 1.595 3.804 3.905 3.804 2.394 0 4.122-1.51 4.122-3.905-.003-2.093-1.32-3.906-4.01-3.906zm-.054 6.154c-1.165 0-1.763-.997-1.763-2.292 0-1.414.676-2.23 1.778-2.23 1.015 0 1.83.677 1.83 2.196 0 1.438-.73 2.327-1.846 2.327zm-5.906-3.564c0-1.78-1.224-2.594-2.577-2.594a2.51 2.51 0 0 0-2.44 1.612c-.367-1.1-1.364-1.613-2.443-1.613a2.48 2.48 0 0 0-2.276 1.278v-1.13h-3.14v1.63h.996v4.24h-.997v1.63h4.572v-1.63h-1.432V40.2c0-1.048.433-1.78 1.448-1.78.845 0 1.278.502 1.278 1.797v4.224h3.14v-1.63h-.996v-2.612c0-1.048.433-1.78 1.447-1.78.846 0 1.278.502 1.278 1.797v4.214h3.142V42.8h-.998zm78.791-22.39h-6.29c.23-1.935 1.16-3.558 3.274-3.558 2.245 0 3.2 1.857 3.016 3.558zM218.952 0v29.137h-169.2V0zM71.706 6.885h-3.85L61.51 20.01h-.104L54.882 6.884h-3.84v1.65h2.19V21.98H51.12v1.65h5.927v-1.65h-2.012V11.24h.1l5.75 11.553H61.9l5.62-11.474h.105v10.66h-1.962v1.65h5.942v-1.65h-2.09V8.536h2.19zm9.993 16.76c5.285 0 8.484-3.48 8.484-8.42 0-4.847-3.094-8.353-8.56-8.353H74.12v1.623h2.114v13.527H74.12v1.623zm27.05-16.76h-6.426v1.65h2.526v11.268h-.1L95.21 6.885H91.6v1.65h2.22V21.98h-1.935v1.65h6.385v-1.65h-2.655V10.444h.1l9.724 13.202h1.21V8.535h2.09zm26.71 5.29h-5.156v1.467h1.83l-1.857 7.247h-.128l-3.586-8.716h-1.21l-3.423 8.718h-.127l-2.14-7.247h1.933v-1.47h-5.41v1.467h1.522l3.25 10.003h1.352l3.432-8.766h.13l3.496 8.765h1.393l3.122-10.003h1.573zm6.704 11.727c2.837 0 4.514-1.583 4.83-3.568l-1.523-.338c-.36 1.42-1.365 2.347-3.17 2.347-2.283 0-3.53-1.468-3.636-4.02h8.058c.1-.445.153-.898.156-1.354-.024-2.71-1.728-5.03-4.873-5.03-3.246 0-5.26 2.58-5.26 6.14 0 3.712 2.162 5.825 5.412 5.825zm13.408 0c3.663 0 5.134-3.25 5.134-6.294 0-3.642-2.063-5.67-4.924-5.67-2.19 0-3.402 1.186-4.1 2.603V5.905h-3.53v1.47h1.692v12.923a22.8 22.8 0 0 1-.338 3.35h1.805a44.05 44.05 0 0 0 .235-1.906c.747 1.39 2.242 2.165 4.02 2.165zm26.198-1.728h-1.985V5.904h-4.6v1.47h2.798v6.653c-.748-1.342-2.15-2.09-3.842-2.09-3.74 0-5.183 3.2-5.183 6.267 0 3.584 1.958 5.698 4.924 5.698 2.087 0 3.352-1.224 4.1-2.577v2.323h3.784zm6.963 1.728c3.53 0 5.75-2.526 5.742-6.006 0-3.25-1.934-5.982-5.647-5.982s-5.67 2.735-5.67 6.087c0 3.457 2.09 5.905 5.568 5.905zm12.942 0c3.172 0 4.538-2.114 4.866-4.112l-1.548-.34c-.334 1.885-1.315 2.917-3.094 2.917-2.27 0-3.507-1.637-3.507-4.397 0-2.475.982-4.487 3.43-4.487a4.4 4.4 0 0 1 2.45.646l.42 1.936 1.496-.18-.44-2.758c-1.16-.876-2.397-1.187-3.92-1.187-3.556 0-5.362 2.966-5.362 6.14 0 3.685 2.036 5.825 5.208 5.825zm11.166 0c2.76 0 4.874-1.34 4.847-3.595 0-4.565-7.1-2.195-7.1-5.184 0-1.177 1.03-1.69 2.474-1.69.826-.015 1.64.18 2.368.567l.267 1.864 1.495-.18-.284-2.68a8.135 8.135 0 0 0-3.997-1.06c-2.088 0-4.255.903-4.255 3.328 0 4.46 7.193 2.063 7.193 5.208 0 1.315-1.495 1.934-3.095 1.934a5.812 5.812 0 0 1-2.553-.568l.078-1.522-1.444-.156-.362 2.604c.977.643 2.736 1.133 4.36 1.133zm-54.042-6.11c0 2.373-1.058 4.564-3.584 4.564a3.455 3.455 0 0 1-3.534-3.456v-1.728c.05-1.7 1.444-3.686 3.635-3.686 1.948 0 3.48 1.444 3.483 4.305zm19.18-1.06v1.833c-.076 1.73-1.57 3.79-3.634 3.79-1.985 0-3.48-1.47-3.48-4.28 0-2.425 1.133-4.59 3.686-4.59a3.36 3.36 0 0 1 3.43 3.248zm14.597 1.133c0 2.58-1.34 4.488-3.79 4.488-2.453 0-3.74-1.958-3.74-4.46 0-2.55 1.34-4.434 3.74-4.434 2.397 0 3.79 1.778 3.79 4.405zm-104.39-2.593c0 4.16-2.32 6.763-6.574 6.763h-3.478V8.508h3.466c4.254 0 6.574 2.71 6.587 6.764zM.116 0h47.956v47.956H.116zM42.01 22.02c-.036-.723-.12-1.448-.17-2.166a1.74 1.74 0 0 0-.395-.98 2.465 2.465 0 0 0-1.026-.74c-.808-.314-1.622-.664-2.435-.975a21.509 21.509 0 0 1-3.342-1.472 2.626 2.626 0 0 1-1.296-1.972 2.954 2.954 0 0 0-1.47-2.228 4.062 4.062 0 0 0-2.958-.35c-.734.176-1.5.165-2.23-.033l-1.112-.34-.302-.09-.873-.26c-1.57-.468-2.228-.713-4.773-.278a14.678 14.678 0 0 0-7.09 3.897l-6.37 6.76h5.72l-3.504 3.71h6.026l-3.503 3.71h4.844l-1.548 4.06c5.93 6.07 12.25 7.295 12.25 7.295 0-1.673.38-8.24.826-9.34a5.25 5.25 0 0 1 .762-1.54 4.211 4.211 0 0 1 3.393-1.547c1.303 0 2.597.238 3.815.702.74.31 1.577.264 2.277-.122a38.42 38.42 0 0 0 1.498-.94.839.839 0 0 1 .556-.18c.54.06 1.054-.237 1.27-.734.16-.33.35-.64.524-.97.472-.884.69-1.88.633-2.88z">
-                    </path>
-                </svg></a>
-            <nav class="main-nav" role="navigation">
-                <ul>
-                    <li class="top-level-entry-container"><button type="button" class="top-level-entry"
-                            aria-haspopup="true">Technologies<span class="main-menu-arrow"
-                                aria-hidden="true">▼</span></button>
-                        <ul>
-                            <li data-item="Technologies" role="menuitem"><a href="/en-US/docs/Web">Technologies
-                                    Overview</a></li>
-                            <li data-item="Technologies" role="menuitem"><a href="/en-US/docs/Web/HTML">HTML</a></li>
-                            <li data-item="Technologies" role="menuitem"><a href="/en-US/docs/Web/CSS">CSS</a></li>
-                            <li data-item="Technologies" role="menuitem"><a
-                                    href="/en-US/docs/Web/JavaScript">JavaScript</a></li>
-                            <li data-item="Technologies" role="menuitem"><a
-                                    href="/en-US/docs/Web/Guide/Graphics">Graphics</a></li>
-                            <li data-item="Technologies" role="menuitem"><a href="/en-US/docs/Web/HTTP">HTTP</a></li>
-                            <li data-item="Technologies" role="menuitem"><a href="/en-US/docs/Web/API">APIs / DOM</a>
-                            </li>
-                            <li data-item="Technologies" role="menuitem"><a
-                                    href="/en-US/docs/Mozilla/Add-ons/WebExtensions">Browser Extensions</a></li>
-                            <li data-item="Technologies" role="menuitem"><a href="/en-US/docs/Web/MathML">MathML</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="top-level-entry-container"><button type="button" class="top-level-entry"
-                            aria-haspopup="true">References &amp; Guides<span class="main-menu-arrow"
-                                aria-hidden="true">▼</span></button>
-                        <ul>
-                            <li data-item="References &amp; Guides" role="menuitem"><a href="/en-US/docs/Learn">Learn
-                                    web development</a></li>
-                            <li data-item="References &amp; Guides" role="menuitem"><a
-                                    href="/en-US/docs/Web/Tutorials">Tutorials</a></li>
-                            <li data-item="References &amp; Guides" role="menuitem"><a
-                                    href="/en-US/docs/Web/Reference">References</a></li>
-                            <li data-item="References &amp; Guides" role="menuitem"><a
-                                    href="/en-US/docs/Web/Guide">Developer Guides</a></li>
-                            <li data-item="References &amp; Guides" role="menuitem"><a
-                                    href="/en-US/docs/Web/Accessibility">Accessibility</a></li>
-                            <li data-item="References &amp; Guides" role="menuitem"><a href="/en-US/docs/Games">Game
-                                    development</a></li>
-                            <li data-item="References &amp; Guides" role="menuitem"><a href="/en-US/docs/Web">...more
-                                    docs</a></li>
-                        </ul>
-                    </li>
-                    <li class="top-level-entry-container"><button type="button" class="top-level-entry"
-                            aria-haspopup="true">Feedback<span class="main-menu-arrow"
-                                aria-hidden="true">▼</span></button>
-                        <ul>
-                            <li data-item="Feedback" role="menuitem"><a href="/en-US/docs/MDN/Feedback">Send
-                                    Feedback</a></li>
-                            <li data-item="Feedback" role="menuitem"><a target="_blank" rel="noopener noreferrer"
-                                    href="https://support.mozilla.org/">Get Firefox help
-                                    <!-- --> 🌐</a></li>
-                            <li data-item="Feedback" role="menuitem"><a target="_blank" rel="noopener noreferrer"
-                                    href="https://stackoverflow.com/">Get web development help
-                                    <!-- --> 🌐</a></li>
-                            <li data-item="Feedback" role="menuitem"><a href="/en-US/docs/MDN/Community">Join the MDN
-                                    community</a></li>
-                            <li data-item="Feedback" role="menuitem"><a target="_blank" rel="noopener noreferrer"
-                                    href="https://github.com/mdn/sprints/issues/new?template=issue-template.md&amp;projects=mdn/sprints/2&amp;labels=user-report&amp;title=%2Fen-US%2Fdocs%2FWeb%2FJavaScript%2FReference%2FGlobal_Objects%2FArray%2FforEach">Report
-                                    a content problem
-                                    <!-- --> 🌐</a></li>
-                            <li data-item="Feedback" role="menuitem"><a target="_blank" rel="noopener noreferrer"
-                                    href="https://github.com/mdn/kuma/issues/new">Report an issue
-                                    <!-- --> 🌐</a></li>
-                        </ul>
-                    </li>
-                </ul>
+      <div class="loading-bar"></div>
+      <ul id="nav-access">
+        <li><a id="skip-main" href="#content">Skip to main content</a></li>
+        <li><a id="skip-language" href="#language">Select language</a></li>
+        <li><a id="skip-search" href="#main-q">Skip to search</a></li>
+      </ul>
+      <header class="page-header">
+        <a href="/" class="logo" aria-label="MDN Web Docs"
+          ><svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 219 48"
+            role="img"
+          >
+            <path
+              d="M49.752 30.824h59.917v17.132H49.75zm57.23 12.3c-.103.03-.21.048-.316.05-.338 0-.514-.15-.514-.582v-3.256c0-1.71-1.352-2.543-2.976-2.543a7.206 7.206 0 0 0-3.21.676l-.29 1.724 1.71.182.245-.842a2.338 2.338 0 0 1 1.147-.216c1.214 0 1.23.913 1.23 1.69v.234c-.407-.048-.818-.07-1.23-.068-1.71 0-3.49.433-3.49 2.276 0 1.563 1.23 2.144 2.31 2.144a2.7 2.7 0 0 0 2.41-1.494c.018.88.77 1.563 1.648 1.494a2.89 2.89 0 0 0 1.353-.338zm-4.604-.05a.787.787 0 0 1-.88-.867c0-.815.677-1.015 1.432-1.015.36.008.722.04 1.078.098-.05 1.235-.852 1.783-1.63 1.783zM97.388 33l-3.24 11.433h2.11L99.5 33.002zm-4.353 0l-3.24 11.433h2.11L95.145 33zm-6.89 6.645h2.243V36.94h-2.242zm0 4.802h2.243v-2.706h-2.242zm-3.617-1.64H80.1l4.156-4.736-.166-1.13h-6.58l-.268 2.63 1.546.164.338-1.163h2.343l-4.123 4.734.216 1.13h6.544l.467-2.63-1.69-.164zM72.143 36.79c-2.706 0-4.02 1.812-4.02 4.004 0 2.394 1.595 3.804 3.905 3.804 2.394 0 4.122-1.51 4.122-3.905-.003-2.093-1.32-3.906-4.01-3.906zm-.054 6.154c-1.165 0-1.763-.997-1.763-2.292 0-1.414.676-2.23 1.778-2.23 1.015 0 1.83.677 1.83 2.196 0 1.438-.73 2.327-1.846 2.327zm-5.906-3.564c0-1.78-1.224-2.594-2.577-2.594a2.51 2.51 0 0 0-2.44 1.612c-.367-1.1-1.364-1.613-2.443-1.613a2.48 2.48 0 0 0-2.276 1.278v-1.13h-3.14v1.63h.996v4.24h-.997v1.63h4.572v-1.63h-1.432V40.2c0-1.048.433-1.78 1.448-1.78.845 0 1.278.502 1.278 1.797v4.224h3.14v-1.63h-.996v-2.612c0-1.048.433-1.78 1.447-1.78.846 0 1.278.502 1.278 1.797v4.214h3.142V42.8h-.998zm78.791-22.39h-6.29c.23-1.935 1.16-3.558 3.274-3.558 2.245 0 3.2 1.857 3.016 3.558zM218.952 0v29.137h-169.2V0zM71.706 6.885h-3.85L61.51 20.01h-.104L54.882 6.884h-3.84v1.65h2.19V21.98H51.12v1.65h5.927v-1.65h-2.012V11.24h.1l5.75 11.553H61.9l5.62-11.474h.105v10.66h-1.962v1.65h5.942v-1.65h-2.09V8.536h2.19zm9.993 16.76c5.285 0 8.484-3.48 8.484-8.42 0-4.847-3.094-8.353-8.56-8.353H74.12v1.623h2.114v13.527H74.12v1.623zm27.05-16.76h-6.426v1.65h2.526v11.268h-.1L95.21 6.885H91.6v1.65h2.22V21.98h-1.935v1.65h6.385v-1.65h-2.655V10.444h.1l9.724 13.202h1.21V8.535h2.09zm26.71 5.29h-5.156v1.467h1.83l-1.857 7.247h-.128l-3.586-8.716h-1.21l-3.423 8.718h-.127l-2.14-7.247h1.933v-1.47h-5.41v1.467h1.522l3.25 10.003h1.352l3.432-8.766h.13l3.496 8.765h1.393l3.122-10.003h1.573zm6.704 11.727c2.837 0 4.514-1.583 4.83-3.568l-1.523-.338c-.36 1.42-1.365 2.347-3.17 2.347-2.283 0-3.53-1.468-3.636-4.02h8.058c.1-.445.153-.898.156-1.354-.024-2.71-1.728-5.03-4.873-5.03-3.246 0-5.26 2.58-5.26 6.14 0 3.712 2.162 5.825 5.412 5.825zm13.408 0c3.663 0 5.134-3.25 5.134-6.294 0-3.642-2.063-5.67-4.924-5.67-2.19 0-3.402 1.186-4.1 2.603V5.905h-3.53v1.47h1.692v12.923a22.8 22.8 0 0 1-.338 3.35h1.805a44.05 44.05 0 0 0 .235-1.906c.747 1.39 2.242 2.165 4.02 2.165zm26.198-1.728h-1.985V5.904h-4.6v1.47h2.798v6.653c-.748-1.342-2.15-2.09-3.842-2.09-3.74 0-5.183 3.2-5.183 6.267 0 3.584 1.958 5.698 4.924 5.698 2.087 0 3.352-1.224 4.1-2.577v2.323h3.784zm6.963 1.728c3.53 0 5.75-2.526 5.742-6.006 0-3.25-1.934-5.982-5.647-5.982s-5.67 2.735-5.67 6.087c0 3.457 2.09 5.905 5.568 5.905zm12.942 0c3.172 0 4.538-2.114 4.866-4.112l-1.548-.34c-.334 1.885-1.315 2.917-3.094 2.917-2.27 0-3.507-1.637-3.507-4.397 0-2.475.982-4.487 3.43-4.487a4.4 4.4 0 0 1 2.45.646l.42 1.936 1.496-.18-.44-2.758c-1.16-.876-2.397-1.187-3.92-1.187-3.556 0-5.362 2.966-5.362 6.14 0 3.685 2.036 5.825 5.208 5.825zm11.166 0c2.76 0 4.874-1.34 4.847-3.595 0-4.565-7.1-2.195-7.1-5.184 0-1.177 1.03-1.69 2.474-1.69.826-.015 1.64.18 2.368.567l.267 1.864 1.495-.18-.284-2.68a8.135 8.135 0 0 0-3.997-1.06c-2.088 0-4.255.903-4.255 3.328 0 4.46 7.193 2.063 7.193 5.208 0 1.315-1.495 1.934-3.095 1.934a5.812 5.812 0 0 1-2.553-.568l.078-1.522-1.444-.156-.362 2.604c.977.643 2.736 1.133 4.36 1.133zm-54.042-6.11c0 2.373-1.058 4.564-3.584 4.564a3.455 3.455 0 0 1-3.534-3.456v-1.728c.05-1.7 1.444-3.686 3.635-3.686 1.948 0 3.48 1.444 3.483 4.305zm19.18-1.06v1.833c-.076 1.73-1.57 3.79-3.634 3.79-1.985 0-3.48-1.47-3.48-4.28 0-2.425 1.133-4.59 3.686-4.59a3.36 3.36 0 0 1 3.43 3.248zm14.597 1.133c0 2.58-1.34 4.488-3.79 4.488-2.453 0-3.74-1.958-3.74-4.46 0-2.55 1.34-4.434 3.74-4.434 2.397 0 3.79 1.778 3.79 4.405zm-104.39-2.593c0 4.16-2.32 6.763-6.574 6.763h-3.478V8.508h3.466c4.254 0 6.574 2.71 6.587 6.764zM.116 0h47.956v47.956H.116zM42.01 22.02c-.036-.723-.12-1.448-.17-2.166a1.74 1.74 0 0 0-.395-.98 2.465 2.465 0 0 0-1.026-.74c-.808-.314-1.622-.664-2.435-.975a21.509 21.509 0 0 1-3.342-1.472 2.626 2.626 0 0 1-1.296-1.972 2.954 2.954 0 0 0-1.47-2.228 4.062 4.062 0 0 0-2.958-.35c-.734.176-1.5.165-2.23-.033l-1.112-.34-.302-.09-.873-.26c-1.57-.468-2.228-.713-4.773-.278a14.678 14.678 0 0 0-7.09 3.897l-6.37 6.76h5.72l-3.504 3.71h6.026l-3.503 3.71h4.844l-1.548 4.06c5.93 6.07 12.25 7.295 12.25 7.295 0-1.673.38-8.24.826-9.34a5.25 5.25 0 0 1 .762-1.54 4.211 4.211 0 0 1 3.393-1.547c1.303 0 2.597.238 3.815.702.74.31 1.577.264 2.277-.122a38.42 38.42 0 0 0 1.498-.94.839.839 0 0 1 .556-.18c.54.06 1.054-.237 1.27-.734.16-.33.35-.64.524-.97.472-.884.69-1.88.633-2.88z"
+            ></path></svg
+        ></a>
+        <nav class="main-nav" role="navigation">
+          <ul>
+            <li class="top-level-entry-container">
+              <button
+                type="button"
+                class="top-level-entry"
+                aria-haspopup="true"
+              >
+                Technologies<span class="main-menu-arrow" aria-hidden="true"
+                  >▼</span
+                >
+              </button>
+              <ul>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">Technologies Overview</a>
+                </li>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">HTML</a>
+                </li>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">CSS</a>
+                </li>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">JavaScript</a>
+                </li>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">Graphics</a>
+                </li>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">HTTP</a>
+                </li>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">APIs / DOM</a>
+                </li>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">Browser Extensions</a>
+                </li>
+                <li data-item="Technologies" role="menuitem">
+                  <a href="/">MathML</a>
+                </li>
+              </ul>
+            </li>
+            <li class="top-level-entry-container">
+              <button
+                type="button"
+                class="top-level-entry"
+                aria-haspopup="true"
+              >
+                References &amp; Guides<span
+                  class="main-menu-arrow"
+                  aria-hidden="true"
+                  >▼</span
+                >
+              </button>
+              <ul>
+                <li data-item="References &amp; Guides" role="menuitem">
+                  <a href="/">Learn web development</a>
+                </li>
+                <li data-item="References &amp; Guides" role="menuitem">
+                  <a href="/">Tutorials</a>
+                </li>
+                <li data-item="References &amp; Guides" role="menuitem">
+                  <a href="/">References</a>
+                </li>
+                <li data-item="References &amp; Guides" role="menuitem">
+                  <a href="/">Developer Guides</a>
+                </li>
+                <li data-item="References &amp; Guides" role="menuitem">
+                  <a href="/">Accessibility</a>
+                </li>
+                <li data-item="References &amp; Guides" role="menuitem">
+                  <a href="/">Game development</a>
+                </li>
+                <li data-item="References &amp; Guides" role="menuitem">
+                  <a href="/">...more docs</a>
+                </li>
+              </ul>
+            </li>
+            <li class="top-level-entry-container">
+              <button
+                type="button"
+                class="top-level-entry"
+                aria-haspopup="true"
+              >
+                Feedback<span class="main-menu-arrow" aria-hidden="true"
+                  >▼</span
+                >
+              </button>
+              <ul>
+                <li data-item="Feedback" role="menuitem">
+                  <a href="/">Send Feedback</a>
+                </li>
+                <li data-item="Feedback" role="menuitem">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://support.mozilla.org/"
+                    >Get Firefox help
+                    <!-- -->
+                    🌐</a
+                  >
+                </li>
+                <li data-item="Feedback" role="menuitem">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://stackoverflow.com/"
+                    >Get web development help
+                    <!-- -->
+                    🌐</a
+                  >
+                </li>
+                <li data-item="Feedback" role="menuitem">
+                  <a href="/">Join the MDN community</a>
+                </li>
+                <li data-item="Feedback" role="menuitem">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/mdn/sprints/issues/new?template=issue-template.md&amp;projects=mdn/sprints/2&amp;labels=user-report&amp;title=%2Fen-US%2Fdocs%2FWeb%2FJavaScript%2FReference%2FGlobal_Objects%2FArray%2FforEach"
+                    >Report a content problem
+                    <!-- -->
+                    🌐</a
+                  >
+                </li>
+                <li data-item="Feedback" role="menuitem">
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://github.com/mdn/kuma/issues/new"
+                    >Report an issue
+                    <!-- -->
+                    🌐</a
+                  >
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+        <form
+          class="header-search"
+          id="nav-main-search"
+          action="/"
+          method="get"
+          role="search"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 26 28"
+            aria-hidden="true"
+            class="search-icon"
+          >
+            <path
+              d="M18 13c0-3.859-3.141-7-7-7s-7 3.141-7 7 3.141 7 7 7 7-3.141 7-7zm8 13c0 1.094-.906 2-2 2a1.96 1.96 0 0 1-1.406-.594l-5.359-5.344a10.971 10.971 0 0 1-6.234 1.937c-6.078 0-11-4.922-11-11s4.922-11 11-11 11 4.922 11 11c0 2.219-.672 4.406-1.937 6.234l5.359 5.359c.359.359.578.875.578 1.406z"
+            ></path></svg
+          ><label for="main-q" class="visually-hidden">Search MDN</label
+          ><input
+            type="search"
+            class="search-input-field"
+            id="main-q"
+            name="q"
+            placeholder="Search MDN"
+            pattern="(.|\s)*\S(.|\s)*"
+            required=""
+          />
+        </form>
+
+        <div class="auth-container">
+          <div class="dropdown-container">
+            <button
+              type="button"
+              class="dropdown-menu-label"
+              aria-haspopup="true"
+            >
+              <img
+                srcset="
+                  https://avatars.githubusercontent.com/u/80675?v=2 200w,
+                  https://avatars.githubusercontent.com/u/80675?v=2  50w
+                "
+                src="https://avatars.githubusercontent.com/u/80675?v=2"
+                class="avatar"
+                alt="schalkneethling"
+              />
+            </button>
+
+            <ul class="dropdown-menu-items" style="right: 0px;" role="menu">
+              <li>
+                <a
+                  href="https://wiki.developer.mozilla.org/en-US/profiles/schalkneethling"
+                  >View profile</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://wiki.developer.mozilla.org/en-US/profiles/schalkneethling/edit"
+                  >Edit profile</a
+                >
+              </li>
+              <li>
+                <form action="/" method="post">
+                  <input name="next" type="hidden" value="" /><button
+                    class="signout-button"
+                    type="submit"
+                  >
+                    Sign out
+                  </button>
+                </form>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <main role="main">
+        <div class="titlebar-container">
+          <div class="titlebar">
+            <h1 class="title">Array.prototype.forEach()</h1>
+            <!-- <a class="button neutral"
+                            href="https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
+                            rel="nofollow"><svg class="icon icon-pencil" xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 24 26" aria-hidden="true">
+                                <path
+                                    d="M5.672 24l1.422-1.422-3.672-3.672L2 20.328V22h2v2h1.672zm8.172-14.5a.329.329 0 0 0-.344-.344.368.368 0 0 0-.266.109l-8.469 8.469a.366.366 0 0 0-.109.266c0 .203.141.344.344.344a.368.368 0 0 0 .266-.109l8.469-8.469a.366.366 0 0 0 .109-.266zM13 6.5l6.5 6.5-13 13H0v-6.5zM23.672 8c0 .531-.219 1.047-.578 1.406L20.5 12 14 5.5l2.594-2.578c.359-.375.875-.594 1.406-.594s1.047.219 1.422.594l3.672 3.656c.359.375.578.891.578 1.422z">
+                                </path>
+                            </svg> Edit in wiki
+                        </a> -->
+          </div>
+        </div>
+        <div class="full-width-row-container">
+          <div class="max-content-width-container">
+            <nav class="breadcrumbs" role="navigation">
+              <ol
+                typeof="BreadcrumbList"
+                vocab="https://schema.org/"
+                aria-label="breadcrumbs"
+              >
+                <li property="itemListElement" typeof="ListItem">
+                  <a
+                    href="/"
+                    class="breadcrumb-chevron"
+                    property="item"
+                    typeof="WebPage"
+                    ><span property="name"
+                      >Web technology for developers</span
+                    ></a
+                  >
+                  <meta property="position" content="1" />
+                </li>
+                <li property="itemListElement" typeof="ListItem">
+                  <a
+                    href="/"
+                    class="breadcrumb-chevron"
+                    property="item"
+                    typeof="WebPage"
+                    ><span property="name">JavaScript</span></a
+                  >
+                  <meta property="position" content="2" />
+                </li>
+                <li property="itemListElement" typeof="ListItem">
+                  <a
+                    href="/"
+                    class="breadcrumb-chevron"
+                    property="item"
+                    typeof="WebPage"
+                    ><span property="name">JavaScript reference</span></a
+                  >
+                  <meta property="position" content="3" />
+                </li>
+                <li property="itemListElement" typeof="ListItem">
+                  <a
+                    href="/"
+                    class="breadcrumb-chevron"
+                    property="item"
+                    typeof="WebPage"
+                    ><span property="name">Standard built-in objects</span></a
+                  >
+                  <meta property="position" content="4" />
+                </li>
+                <li property="itemListElement" typeof="ListItem">
+                  <a
+                    href="/"
+                    class="breadcrumb-chevron"
+                    property="item"
+                    typeof="WebPage"
+                    ><span property="name">Array</span></a
+                  >
+                  <meta property="position" content="5" />
+                </li>
+                <li property="itemListElement" typeof="ListItem">
+                  <a
+                    href="/"
+                    class="crumb-current-page"
+                    property="item"
+                    typeof="WebPage"
+                    ><span property="name" aria-current="page"
+                      >Array.prototype.forEach()</span
+                    ></a
+                  >
+                  <meta property="position" content="6" />
+                </li>
+              </ol>
             </nav>
-            <form class="header-search" id="nav-main-search" action="/en-US/search" method="get" role="search"><svg
-                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 28" aria-hidden="true" class="search-icon">
-                    <path
-                        d="M18 13c0-3.859-3.141-7-7-7s-7 3.141-7 7 3.141 7 7 7 7-3.141 7-7zm8 13c0 1.094-.906 2-2 2a1.96 1.96 0 0 1-1.406-.594l-5.359-5.344a10.971 10.971 0 0 1-6.234 1.937c-6.078 0-11-4.922-11-11s4.922-11 11-11 11 4.922 11 11c0 2.219-.672 4.406-1.937 6.234l5.359 5.359c.359.359.578.875.578 1.406z">
-                    </path>
-                </svg><label for="main-q" class="visually-hidden">Search MDN</label><input type="search"
-                    class="search-input-field" id="main-q" name="q" placeholder="Search MDN" pattern="(.|\s)*\S(.|\s)*"
-                    required=""></form>
-            <div class="auth-container">
-                <div class="dropdown-container"><button type="button" class="dropdown-menu-label"
-                        aria-haspopup="true"><img
-                            srcset="https://avatars.githubusercontent.com/u/80675?v=2 200w, https://avatars.githubusercontent.com/u/80675?v=2 50w"
-                            src="/static/img/avatar.png" class="avatar" alt="schalkneethling"></button>
-                    <ul class="dropdown-menu-items" style="right: 0px;" role="menu">
-                        <li><a href="https://wiki.developer.mozilla.org/en-US/profiles/schalkneethling">View profile</a>
-                        </li>
-                        <li><a href="https://wiki.developer.mozilla.org/en-US/profiles/schalkneethling/edit">Edit
-                                profile</a></li>
-                        <li>
-                            <form action="/en-US/users/signout" method="post"><input name="next" type="hidden"
-                                    value="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"><button
-                                    class="signout-button" type="submit">Sign out</button></form>
-                        </li>
-                    </ul>
-                </div>
+            <div class="dropdown-container">
+              <button
+                type="button"
+                class="dropdown-menu-label"
+                aria-haspopup="true"
+                aria-owns="language-menu"
+                aria-label="Current language is English. Choose your preferred language."
+              >
+                English<span class="dropdown-arrow-down" aria-hidden="true"
+                  >▼</span
+                >
+              </button>
+              <ul
+                id="language-menu"
+                class="dropdown-menu-items"
+                style="right:0"
+                role="menu"
+              >
+                <li role="menuitem" lang="ca">
+                  <a href="/" title="Catalan"><bdi>Català</bdi></a>
+                </li>
+                <li role="menuitem" lang="de">
+                  <a href="/" title="German"><bdi>Deutsch</bdi></a>
+                </li>
+                <li role="menuitem" lang="es">
+                  <a href="/" title="Spanish"><bdi>Español</bdi></a>
+                </li>
+                <li role="menuitem" lang="fr">
+                  <a href="/" title="French"><bdi>Français</bdi></a>
+                </li>
+                <li role="menuitem" lang="he">
+                  <a href="/" title="Hebrew"><bdi>עברית</bdi></a>
+                </li>
+                <li role="menuitem" lang="id">
+                  <a href="/" title="Indonesian"><bdi>Bahasa Indonesia</bdi></a>
+                </li>
+
+                <li role="menuitem" lang="it">
+                  <a href="/" title="Italian"><bdi>Italiano</bdi></a>
+                </li>
+                <li role="menuitem" lang="ja">
+                  <a href="/" title="Japanese"><bdi>日本語</bdi></a>
+                </li>
+                <li role="menuitem" lang="ko">
+                  <a href="/" title="Korean"><bdi>한국어</bdi></a>
+                </li>
+                <li role="menuitem" lang="nl">
+                  <a href="/" title="Dutch"><bdi>Nederlands</bdi></a>
+                </li>
+                <li role="menuitem" lang="pl">
+                  <a href="/" title="Polish"><bdi>Polski</bdi></a>
+                </li>
+                <li role="menuitem" lang="pt-BR">
+                  <a href="/" title="Portuguese (Brazilian)"
+                    ><bdi>Português (do&nbsp;Brasil)</bdi></a
+                  >
+                </li>
+                <li role="menuitem" lang="pt-PT">
+                  <a href="/" title="Portuguese (Portugal)"
+                    ><bdi>Português (Europeu)</bdi></a
+                  >
+                </li>
+                <li role="menuitem" lang="ru">
+                  <a href="/" title="Russian"><bdi>Русский</bdi></a>
+                </li>
+                <li role="menuitem" lang="tr">
+                  <a href="/" title="Turkish"><bdi>Türkçe</bdi></a>
+                </li>
+                <li role="menuitem" lang="uk">
+                  <a href="/" title="Ukrainian"><bdi>Українська</bdi></a>
+                </li>
+                <li role="menuitem" lang="vi">
+                  <a href="/" title="Vietnamese"><bdi>Tiếng Việt</bdi></a>
+                </li>
+                <li role="menuitem" lang="zh-CN">
+                  <a href="/" title="Chinese (Simplified)"
+                    ><bdi>中文 (简体)</bdi></a
+                  >
+                </li>
+                <li role="menuitem" lang="zh-TW">
+                  <a href="/" title="Chinese (Traditional)"
+                    ><bdi>正體中文 (繁體)</bdi></a
+                  >
+                </li>
+                <li>
+                  <!-- <a
+                    href="https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach$locales"
+                    rel="nofollow"
+                    id="translations-add"
+                    >Add a translation</a
+                  > -->
+                </li>
+              </ul>
             </div>
-        </header>
-        <main role="main">
-            <div class="titlebar-container">
-                <div class="titlebar">
-                    <h1 class="title">Array.prototype.forEach()</h1><a class="button neutral"
-                        href="https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                        rel="nofollow"><svg class="icon icon-pencil" xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 24 26" aria-hidden="true">
-                            <path
-                                d="M5.672 24l1.422-1.422-3.672-3.672L2 20.328V22h2v2h1.672zm8.172-14.5a.329.329 0 0 0-.344-.344.368.368 0 0 0-.266.109l-8.469 8.469a.366.366 0 0 0-.109.266c0 .203.141.344.344.344a.368.368 0 0 0 .266-.109l8.469-8.469a.366.366 0 0 0 .109-.266zM13 6.5l6.5 6.5-13 13H0v-6.5zM23.672 8c0 .531-.219 1.047-.578 1.406L20.5 12 14 5.5l2.594-2.578c.359-.375.875-.594 1.406-.594s1.047.219 1.422.594l3.672 3.656c.359.375.578.891.578 1.422z">
-                            </path>
-                        </svg> Edit in wiki</a>
-                </div>
-            </div>
-            <div class="full-width-row-container">
-                <div class="max-content-width-container">
-                    <nav class="breadcrumbs" role="navigation">
-                        <ol typeof="BreadcrumbList" vocab="https://schema.org/" aria-label="breadcrumbs">
-                            <li property="itemListElement" typeof="ListItem"><a href="/en-US/docs/Web"
-                                    class="breadcrumb-chevron" property="item" typeof="WebPage"><span
-                                        property="name">Web technology for developers</span></a>
-                                <meta property="position" content="1">
-                            </li>
-                            <li property="itemListElement" typeof="ListItem"><a href="/en-US/docs/Web/JavaScript"
-                                    class="breadcrumb-chevron" property="item" typeof="WebPage"><span
-                                        property="name">JavaScript</span></a>
-                                <meta property="position" content="2">
-                            </li>
-                            <li property="itemListElement" typeof="ListItem"><a
-                                    href="/en-US/docs/Web/JavaScript/Reference" class="breadcrumb-chevron"
-                                    property="item" typeof="WebPage"><span property="name">JavaScript
-                                        reference</span></a>
-                                <meta property="position" content="3">
-                            </li>
-                            <li property="itemListElement" typeof="ListItem"><a
-                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects"
-                                    class="breadcrumb-chevron" property="item" typeof="WebPage"><span
-                                        property="name">Standard built-in objects</span></a>
-                                <meta property="position" content="4">
-                            </li>
-                            <li property="itemListElement" typeof="ListItem"><a
-                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"
-                                    class="breadcrumb-chevron" property="item" typeof="WebPage"><span
-                                        property="name">Array</span></a>
-                                <meta property="position" content="5">
-                            </li>
-                            <li property="itemListElement" typeof="ListItem"><a
-                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    class="crumb-current-page" property="item" typeof="WebPage"><span property="name"
-                                        aria-current="page">Array.prototype.forEach()</span></a>
-                                <meta property="position" content="6">
-                            </li>
-                        </ol>
-                    </nav>
-                    <div class="dropdown-container"><button type="button" class="dropdown-menu-label"
-                            aria-haspopup="true" aria-owns="language-menu"
-                            aria-label="Current language is English. Choose your preferred language.">English<span
-                                class="dropdown-arrow-down" aria-hidden="true">▼</span></button>
-                        <ul id="language-menu" class="dropdown-menu-items" style="right:0" role="menu">
-                            <li role="menuitem" lang="ca"><a
-                                    href="/ca/docs/Web/JavaScript/Referencia/Objectes_globals/Array/forEach"
-                                    title="Catalan"><bdi>Català</bdi></a></li>
-                            <li role="menuitem" lang="de"><a
-                                    href="/de/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="German"><bdi>Deutsch</bdi></a></li>
-                            <li role="menuitem" lang="es"><a
-                                    href="/es/docs/Web/JavaScript/Referencia/Objetos_globales/Array/forEach"
-                                    title="Spanish"><bdi>Español</bdi></a></li>
-                            <li role="menuitem" lang="fr"><a
-                                    href="/fr/docs/Web/JavaScript/Reference/Objets_globaux/Array/forEach"
-                                    title="French"><bdi>Français</bdi></a></li>
-                            <li role="menuitem" lang="he"><a
-                                    href="/he/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Hebrew"><bdi>עברית</bdi></a></li>
-                            <li role="menuitem" lang="id"><a
-                                    href="/id/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Indonesian"><bdi>Bahasa Indonesia</bdi></a></li>
-                            <li role="menuitem" lang="it"><a
-                                    href="/it/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Italian"><bdi>Italiano</bdi></a></li>
-                            <li role="menuitem" lang="ja"><a
-                                    href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Japanese"><bdi>日本語</bdi></a></li>
-                            <li role="menuitem" lang="ko"><a
-                                    href="/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Korean"><bdi>한국어</bdi></a></li>
-                            <li role="menuitem" lang="nl"><a
-                                    href="/nl/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Dutch"><bdi>Nederlands</bdi></a></li>
-                            <li role="menuitem" lang="pl"><a
-                                    href="/pl/docs/Web/JavaScript/Referencje/Obiekty/Array/forEach"
-                                    title="Polish"><bdi>Polski</bdi></a></li>
-                            <li role="menuitem" lang="pt-BR"><a
-                                    href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Portuguese (Brazilian)"><bdi>Português (do&nbsp;Brasil)</bdi></a></li>
-                            <li role="menuitem" lang="pt-PT"><a
-                                    href="/pt-PT/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Portuguese (Portugal)"><bdi>Português (Europeu)</bdi></a></li>
-                            <li role="menuitem" lang="ru"><a
-                                    href="/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Russian"><bdi>Русский</bdi></a></li>
-                            <li role="menuitem" lang="tr"><a
-                                    href="/tr/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Turkish"><bdi>Türkçe</bdi></a></li>
-                            <li role="menuitem" lang="uk"><a
-                                    href="/uk/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Ukrainian"><bdi>Українська</bdi></a></li>
-                            <li role="menuitem" lang="vi"><a
-                                    href="/vi/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Vietnamese"><bdi>Tiếng Việt</bdi></a></li>
-                            <li role="menuitem" lang="zh-CN"><a
-                                    href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Chinese (Simplified)"><bdi>中文 (简体)</bdi></a></li>
-                            <li role="menuitem" lang="zh-TW"><a
-                                    href="/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach"
-                                    title="Chinese (Traditional)"><bdi>正體中文 (繁體)</bdi></a></li>
-                            <li><a href="https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach$locales"
-                                    rel="nofollow" id="translations-add">Add a translation</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="wiki-left-present content-layout">
-                <aside class="document-toc-container">
-                    <section class="document-toc">
-                        <header>
-                            <h2>On this Page</h2>
-                        </header>
-                        <ul>
-                            <li><a href="#Syntax" rel="internal">Syntax</a></li>
-                            <li><a href="#Description" rel="internal">Description</a></li>
-                            <li><a href="#Examples" rel="internal">Examples</a></li>
-                            <li><a href="#Note_on_using_Promises_or_async_functions" rel="internal">Note on using
-                                    Promises or async functions</a></li>
-                            <li><a href="#Specifications" rel="internal">Specifications</a></li>
-                            <li><a href="#Browser_compatibility" rel="internal">Browser compatibility</a></li>
-                            <li><a href="#See_also" rel="internal">See also</a></li>
-                        </ul>
-                    </section>
-                </aside>
-                <div id="content" class="article text-content">
-                    <article id="wikiArticle">
-                        <div></div>
+          </div>
+        </div>
+        <div class="wiki-left-present content-layout">
+          <aside class="document-toc-container">
+            <section class="document-toc">
+              <header>
+                <h2>On this Page</h2>
+              </header>
+              <ul>
+                <li><a href="#Syntax" rel="internal">Syntax</a></li>
+                <li><a href="#Description" rel="internal">Description</a></li>
+                <li><a href="#Examples" rel="internal">Examples</a></li>
+                <li>
+                  <a
+                    href="#Note_on_using_Promises_or_async_functions"
+                    rel="internal"
+                    >Note on using Promises or async functions</a
+                  >
+                </li>
+                <li>
+                  <a href="#Specifications" rel="internal">Specifications</a>
+                </li>
+                <li>
+                  <a href="#Browser_compatibility" rel="internal"
+                    >Browser compatibility</a
+                  >
+                </li>
+                <li><a href="#See_also" rel="internal">See also</a></li>
+              </ul>
+            </section>
+          </aside>
+          <div id="content" class="article text-content">
+            <article id="wikiArticle">
+              <div></div>
 
-                        <p>The <code><strong>forEach()</strong></code> method executes a provided function once for each
-                            array element.</p>
+              <p>
+                The <code><strong>forEach()</strong></code> method executes a
+                provided function once for each array element.
+              </p>
 
-                        <div><iframe class="interactive interactive-js"
-                                src="https://interactive-examples.mdn.mozilla.net/pages/js/array-foreach.html"
-                                title="MDN Web Docs Interactive Example" width="100%" height="250"
-                                frameborder="0"></iframe></div>
+              <div>
+                <iframe
+                  class="interactive interactive-js"
+                  src="https://interactive-examples.mdn.mozilla.net/pages/js/array-foreach.html"
+                  title="MDN Web Docs Interactive Example"
+                  width="100%"
+                  height="250"
+                  frameborder="0"
+                ></iframe>
+              </div>
 
-                        <p class="hidden">The source for this interactive example is stored in a GitHub repository. If
-                            you'd like to contribute to the interactive examples project, please clone <a
-                                class="external" href="https://github.com/mdn/interactive-examples"
-                                rel="noopener">https://github.com/mdn/interactive-examples</a> and send us a pull
-                            request.</p>
+              <p class="hidden">
+                The source for this interactive example is stored in a GitHub
+                repository. If you'd like to contribute to the interactive
+                examples project, please clone
+                <a
+                  class="external"
+                  href="https://github.com/mdn/interactive-examples"
+                  rel="noopener"
+                  >https://github.com/mdn/interactive-examples</a
+                >
+                and send us a pull request.
+              </p>
 
-                        <h2 id="Syntax">Syntax</h2>
+              <h2 id="Syntax">Syntax</h2>
 
-                        <pre
-                            class="syntaxbox"><var>arr</var>.forEach(<var>callback(currentValue [, index [, array]])</var>[, <var>thisArg</var>])</pre>
+              <pre
+                class="syntaxbox"
+              ><var>arr</var>.forEach(<var>callback(currentValue [, index [, array]])</var>[, <var>thisArg</var>])</pre>
 
-                        <h3 id="Parameters">Parameters</h3>
+              <h3 id="Parameters">Parameters</h3>
 
-                        <dl>
-                            <dt><code><var>callback</var></code></dt>
-                            <dd>Function to execute on each element. It accepts between one and&nbsp;three arguments:
-                            </dd>
-                            <dd>
-                                <dl>
-                                    <dt><code><var>currentValue</var></code></dt>
-                                    <dd>The current element being processed in the array.</dd>
-                                    <dt><code><var>index</var></code> <span
-                                            class="inlineIndicator optional optionalInline">Optional</span></dt>
-                                    <dd>The index <code><var>currentValue</var></code>&nbsp;in the array.</dd>
-                                    <dt><code><var>array</var></code> <span
-                                            class="inlineIndicator optional optionalInline">Optional</span></dt>
-                                    <dd>The array <code>forEach()</code> was called upon.</dd>
-                                </dl>
-                            </dd>
-                            <dt><code><var>thisArg</var></code> <span
-                                    class="inlineIndicator optional optionalInline">Optional</span></dt>
-                            <dd>Value to use as <code>this</code> when executing <code><var>callback</var></code>.</dd>
-                        </dl>
+              <dl>
+                <dt>
+                  <code><var>callback</var></code>
+                </dt>
+                <dd>
+                  Function to execute on each element. It accepts between one
+                  and&nbsp;three arguments:
+                </dd>
+                <dd>
+                  <dl>
+                    <dt>
+                      <code><var>currentValue</var></code>
+                    </dt>
+                    <dd>The current element being processed in the array.</dd>
+                    <dt>
+                      <code><var>index</var></code>
+                      <span class="inlineIndicator optional optionalInline"
+                        >Optional</span
+                      >
+                    </dt>
+                    <dd>
+                      The index <code><var>currentValue</var></code
+                      >&nbsp;in the array.
+                    </dd>
+                    <dt>
+                      <code><var>array</var></code>
+                      <span class="inlineIndicator optional optionalInline"
+                        >Optional</span
+                      >
+                    </dt>
+                    <dd>The array <code>forEach()</code> was called upon.</dd>
+                  </dl>
+                </dd>
+                <dt>
+                  <code><var>thisArg</var></code>
+                  <span class="inlineIndicator optional optionalInline"
+                    >Optional</span
+                  >
+                </dt>
+                <dd>
+                  Value to use as <code>this</code> when executing
+                  <code><var>callback</var></code
+                  >.
+                </dd>
+              </dl>
 
-                        <h3 id="Return_value">Return value</h3>
+              <h3 id="Return_value">Return value</h3>
 
-                        <p><code>undefined</code>.</p>
+              <p><code>undefined</code>.</p>
 
-                        <h2 id="Description">Description</h2>
+              <h2 id="Description">Description</h2>
 
-                        <p><code>forEach()</code> calls a provided <code><var>callback</var></code> function once for
-                            each element in an array in ascending order. It is not invoked for index properties that
-                            have been deleted or are uninitialized. (For sparse arrays, <a href="#sparseArray">see
-                                example below</a>.)</p>
+              <p>
+                <code>forEach()</code> calls a provided
+                <code><var>callback</var></code> function once for each element
+                in an array in ascending order. It is not invoked for index
+                properties that have been deleted or are uninitialized. (For
+                sparse arrays, <a href="#sparseArray">see example below</a>.)
+              </p>
 
-                        <p><code><var>callback</var></code> is invoked with three arguments:</p>
+              <p>
+                <code><var>callback</var></code> is invoked with three
+                arguments:
+              </p>
 
-                        <ol>
-                            <li>the value of the element</li>
-                            <li>the index of the element</li>
-                            <li>the Array object being traversed</li>
-                        </ol>
+              <ol>
+                <li>the value of the element</li>
+                <li>the index of the element</li>
+                <li>the Array object being traversed</li>
+              </ol>
 
-                        <p>If a <code><var>thisArg</var></code> parameter is provided to <code>forEach()</code>, it will
-                            be used as callback's <code>this</code> value. The <code><var>thisArg</var></code> value
-                            ultimately observable by <code><var>callback</var></code> is determined according to <a
-                                href="/en-US/docs/Web/JavaScript/Reference/Operators/this">the usual rules for
-                                determining the <code>this</code> seen by a function</a>.</p>
+              <p>
+                If a <code><var>thisArg</var></code> parameter is provided to
+                <code>forEach()</code>, it will be used as callback's
+                <code>this</code> value. The
+                <code><var>thisArg</var></code> value ultimately observable by
+                <code><var>callback</var></code> is determined according to
+                <a href="/"
+                  >the usual rules for determining the <code>this</code> seen by
+                  a function</a
+                >.
+              </p>
 
-                        <p>The range of elements processed by <code>forEach()</code> is set before the first invocation
-                            of <code><var>callback</var></code>. Elements which are appended to the array after the call
-                            to <code>forEach()</code> begins will not be visited by <code><var>callback</var></code>. If
-                            existing elements of the array are changed or deleted, their value as passed to
-                            <code><var>callback</var></code> will be the value at the time <code>forEach()</code> visits
-                            them; elements that are deleted before being visited are not visited. If elements that are
-                            already visited are removed (e.g. using <a
-                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift"
-                                title="The shift() method removes the first element from an array and returns that removed element. This method changes the length of the array."><code>shift()</code></a>)
-                            during the iteration, later elements will be skipped. (<a
-                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#If_the_array_is_modified_during_iteration_other_elements_might_be_skipped.">See
-                                this example, below</a>.)</p>
+              <p>
+                The range of elements processed by <code>forEach()</code> is set
+                before the first invocation of <code><var>callback</var></code
+                >. Elements which are appended to the array after the call to
+                <code>forEach()</code> begins will not be visited by
+                <code><var>callback</var></code
+                >. If existing elements of the array are changed or deleted,
+                their value as passed to <code><var>callback</var></code> will
+                be the value at the time <code>forEach()</code> visits them;
+                elements that are deleted before being visited are not visited.
+                If elements that are already visited are removed (e.g. using
+                <a
+                  href="/"
+                  title="The shift() method removes the first element from an array and returns that removed element. This method changes the length of the array."
+                  ><code>shift()</code></a
+                >) during the iteration, later elements will be skipped. (<a
+                  href="/"
+                  >See this example, below</a
+                >.)
+              </p>
 
-                        <p><code>forEach()</code> executes the <code><var>callback</var></code> function once for each
-                            array element; unlike <a
-                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map"
-                                title="The map() method creates a new array with the results of calling a provided function on every element in the calling&nbsp;array."><code>map()</code></a>
-                            or <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce"
-                                title="The reduce() method executes a reducer function (that you provide) on each element of the array, resulting in a single output value."><code>reduce()</code></a>
-                            it always returns the value <a
-                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined"
-                                title="The global undefined property represents the primitive value undefined. It is one of JavaScript's primitive types."><code>undefined</code></a>
-                            and is not chainable. The typical use case is to execute side effects at the end of a chain.
-                        </p>
+              <p>
+                <code>forEach()</code> executes the
+                <code><var>callback</var></code> function once for each array
+                element; unlike
+                <a
+                  href="/"
+                  title="The map() method creates a new array with the results of calling a provided function on every element in the calling&nbsp;array."
+                  ><code>map()</code></a
+                >
+                or
+                <a
+                  href="/"
+                  title="The reduce() method executes a reducer function (that you provide) on each element of the array, resulting in a single output value."
+                  ><code>reduce()</code></a
+                >
+                it always returns the value
+                <a
+                  href="/"
+                  title="The global undefined property represents the primitive value undefined. It is one of JavaScript's primitive types."
+                  ><code>undefined</code></a
+                >
+                and is not chainable. The typical use case is to execute side
+                effects at the end of a chain.
+              </p>
 
-                        <p><code>forEach()</code> does not mutate the array on which it is called.
-                            (However,&nbsp;<code><var>callback</var></code>&nbsp;may do so)</p>
+              <p>
+                <code>forEach()</code> does not mutate the array on which it is
+                called. (However,&nbsp;<code><var>callback</var></code
+                >&nbsp;may do so)
+              </p>
 
-                        <div class="note">
-                            <p>There is no way to stop or break a <code>forEach()</code> loop other than by throwing an
-                                exception. If you need such behavior, the <code>forEach()</code> method is the wrong
-                                tool.</p>
+              <div class="note">
+                <p>
+                  There is no way to stop or break a <code>forEach()</code> loop
+                  other than by throwing an exception. If you need such
+                  behavior, the <code>forEach()</code> method is the wrong tool.
+                </p>
 
-                            <p>Early termination may be accomplished with:</p>
+                <p>Early termination may be accomplished with:</p>
 
-                            <ul>
-                                <li>A simple <a href="/en-US/docs/Web/JavaScript/Reference/Statements/for">for</a> loop
-                                </li>
-                                <li>A <a
-                                        href="/en-US/docs/Web/JavaScript/Reference/Statements/for...of">for...of</a>&nbsp;/
-                                    <a
-                                        href="/en-US/docs/Web/JavaScript/Reference/Statements/for...in">for...in</a>&nbsp;loops
-                                </li>
-                                <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every"
-                                        title="The every() method tests whether all elements in the array pass the test implemented by the provided function. It returns a Boolean value."><code>Array.prototype.every()</code></a>
-                                </li>
-                                <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some"
-                                        title="The some() method tests whether at least one&nbsp;element in the array passes the test implemented by the provided function. It returns a Boolean value."><code>Array.prototype.some()</code></a>
-                                </li>
-                                <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find"
-                                        title="The find() method returns the value of the first element in the provided array that satisfies the provided testing function."><code>Array.prototype.find()</code></a>
-                                </li>
-                                <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex"
-                                        title="The findIndex() method returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating that no element passed the test."><code>Array.prototype.findIndex()</code></a>
-                                </li>
-                            </ul>
+                <ul>
+                  <li>
+                    A simple
+                    <a href="/">for</a>
+                    loop
+                  </li>
+                  <li>
+                    A
+                    <a href="/">for...of</a>&nbsp;/
+                    <a href="/">for...in</a>&nbsp;loops
+                  </li>
+                  <li>
+                    <a
+                      href="/"
+                      title="The every() method tests whether all elements in the array pass the test implemented by the provided function. It returns a Boolean value."
+                      ><code>Array.prototype.every()</code></a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      href="/"
+                      title="The some() method tests whether at least one&nbsp;element in the array passes the test implemented by the provided function. It returns a Boolean value."
+                      ><code>Array.prototype.some()</code></a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      href="/"
+                      title="The find() method returns the value of the first element in the provided array that satisfies the provided testing function."
+                      ><code>Array.prototype.find()</code></a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      href="/"
+                      title="The findIndex() method returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating that no element passed the test."
+                      ><code>Array.prototype.findIndex()</code></a
+                    >
+                  </li>
+                </ul>
 
-                            <p>Array methods: <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every"
-                                    title="The every() method tests whether all elements in the array pass the test implemented by the provided function. It returns a Boolean value."><code>every()</code></a>,
-                                <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some"
-                                    title="The some() method tests whether at least one&nbsp;element in the array passes the test implemented by the provided function. It returns a Boolean value."><code>some()</code></a>,
-                                <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find"
-                                    title="The find() method returns the value of the first element in the provided array that satisfies the provided testing function."><code>find()</code></a>,
-                                and <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex"
-                                    title="The findIndex() method returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating that no element passed the test."><code>findIndex()</code></a>
-                                test the array elements with a predicate returning a truthy value to determine if
-                                further iteration is required.</p>
-                        </div>
+                <p>
+                  Array methods:
+                  <a
+                    href="/"
+                    title="The every() method tests whether all elements in the array pass the test implemented by the provided function. It returns a Boolean value."
+                    ><code>every()</code></a
+                  >,
+                  <a
+                    href="/"
+                    title="The some() method tests whether at least one&nbsp;element in the array passes the test implemented by the provided function. It returns a Boolean value."
+                    ><code>some()</code></a
+                  >,
+                  <a
+                    href="/"
+                    title="The find() method returns the value of the first element in the provided array that satisfies the provided testing function."
+                    ><code>find()</code></a
+                  >, and
+                  <a
+                    href="/"
+                    title="The findIndex() method returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating that no element passed the test."
+                    ><code>findIndex()</code></a
+                  >
+                  test the array elements with a predicate returning a truthy
+                  value to determine if further iteration is required.
+                </p>
+              </div>
 
-                        <h2 id="Examples">Examples</h2>
+              <h2 id="Examples">Examples</h2>
 
-                        <h3 id="sparseArray" name="sparseArray">No operation for uninitialized values (sparse arrays)
-                        </h3>
+              <h3 id="sparseArray" name="sparseArray">
+                No operation for uninitialized values (sparse arrays)
+              </h3>
 
-                        <pre
-                            class="brush: js line-numbers language-js"><code class=" language-js"><span class="token keyword">const</span> arraySparse <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token number">1</span><span class="token punctuation">,</span><span class="token number">3</span><span class="token punctuation">,</span><span class="token punctuation">,</span><span class="token number">7</span><span class="token punctuation">]</span>
+              <pre
+                class="brush: js line-numbers language-js"
+              ><code class=" language-js"><span class="token keyword">const</span> arraySparse <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token number">1</span><span class="token punctuation">,</span><span class="token number">3</span><span class="token punctuation">,</span><span class="token punctuation">,</span><span class="token number">7</span><span class="token punctuation">]</span>
 <span class="token keyword">let</span> numCallbackRuns <span class="token operator">=</span> <span class="token number">0</span>
 
 arraySparse<span class="token punctuation">.</span><span class="token function">forEach</span><span class="token punctuation">(</span><span class="token keyword">function</span><span class="token punctuation">(</span><span class="token parameter">element</span><span class="token punctuation">)</span><span class="token punctuation">{</span>
@@ -418,10 +729,13 @@ console<span class="token punctuation">.</span><span class="token function">log<
 <span class="token comment">// numCallbackRuns: 3</span>
 <span class="token comment">// comment: as you can see the missing value between 3 and 7 didn't invoke callback function.</span><span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
 
-                        <h3 id="Converting_a_for_loop_to_forEach">Converting a for loop to forEach</h3>
+              <h3 id="Converting_a_for_loop_to_forEach">
+                Converting a for loop to forEach
+              </h3>
 
-                        <pre
-                            class="brush:js line-numbers language-js"><code class=" language-js"><span class="token keyword">const</span> items <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token string">'item1'</span><span class="token punctuation">,</span> <span class="token string">'item2'</span><span class="token punctuation">,</span> <span class="token string">'item3'</span><span class="token punctuation">]</span>
+              <pre
+                class="brush:js line-numbers language-js"
+              ><code class=" language-js"><span class="token keyword">const</span> items <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token string">'item1'</span><span class="token punctuation">,</span> <span class="token string">'item2'</span><span class="token punctuation">,</span> <span class="token string">'item3'</span><span class="token punctuation">]</span>
 <span class="token keyword">const</span> copy <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token punctuation">]</span>
 
 <span class="token comment">// before</span>
@@ -435,22 +749,32 @@ items<span class="token punctuation">.</span><span class="token function">forEac
 <span class="token punctuation">}</span><span class="token punctuation">)</span>
 <span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
 
-                        <h3 id="Printing_the_contents_of_an_array">Printing the contents of an array</h3>
+              <h3 id="Printing_the_contents_of_an_array">
+                Printing the contents of an array
+              </h3>
 
-                        <div class="blockIndicator note">
-                            <p><strong>Note:</strong> In order to display the content of an array in the console, you
-                                can use <a href="/en-US/docs/Web/API/Console/table"
-                                    title="Displays tabular data as a table."><code>console.table()</code></a>, which
-                                prints a formatted version of the array.</p>
+              <div class="blockIndicator note">
+                <p>
+                  <strong>Note:</strong> In order to display the content of an
+                  array in the console, you can use
+                  <a href="/" title="Displays tabular data as a table."
+                    ><code>console.table()</code></a
+                  >, which prints a formatted version of the array.
+                </p>
 
-                            <p>The following example illustrates an alternative approach, using <code>forEach()</code>.
-                            </p>
-                        </div>
+                <p>
+                  The following example illustrates an alternative approach,
+                  using <code>forEach()</code>.
+                </p>
+              </div>
 
-                        <p>The following code logs a line for each element in an array:</p>
+              <p>
+                The following code logs a line for each element in an array:
+              </p>
 
-                        <pre
-                            class="brush:js line-numbers language-js"><code class=" language-js"><span class="token keyword">function</span> <span class="token function">logArrayElements</span><span class="token punctuation">(</span><span class="token parameter">element<span class="token punctuation">,</span> index<span class="token punctuation">,</span> array</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+              <pre
+                class="brush:js line-numbers language-js"
+              ><code class=" language-js"><span class="token keyword">function</span> <span class="token function">logArrayElements</span><span class="token punctuation">(</span><span class="token parameter">element<span class="token punctuation">,</span> index<span class="token punctuation">,</span> array</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
   console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token string">'a['</span> <span class="token operator">+</span> index <span class="token operator">+</span> <span class="token string">'] = '</span> <span class="token operator">+</span> element<span class="token punctuation">)</span>
 <span class="token punctuation">}</span>
 
@@ -463,13 +787,18 @@ items<span class="token punctuation">.</span><span class="token function">forEac
 <span class="token comment">// a[3] = 9</span>
 <span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
 
-                        <h3 id="Using_thisArg">Using <code><var>thisArg</var></code></h3>
+              <h3 id="Using_thisArg">
+                Using <code><var>thisArg</var></code>
+              </h3>
 
-                        <p>The following (contrived) example updates an object's properties from each entry in the
-                            array:</p>
+              <p>
+                The following (contrived) example updates an object's properties
+                from each entry in the array:
+              </p>
 
-                        <pre
-                            class="brush:js line-numbers language-js"><code class=" language-js"><span class="token keyword">function</span> <span class="token function">Counter</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+              <pre
+                class="brush:js line-numbers language-js"
+              ><code class=" language-js"><span class="token keyword">function</span> <span class="token function">Counter</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
   <span class="token keyword">this</span><span class="token punctuation">.</span>sum <span class="token operator">=</span> <span class="token number">0</span>
   <span class="token keyword">this</span><span class="token punctuation">.</span>count <span class="token operator">=</span> <span class="token number">0</span>
 <span class="token punctuation">}</span>
@@ -489,30 +818,43 @@ obj<span class="token punctuation">.</span>sum
 <span class="token comment">// 16</span>
 <span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
 
-                        <p>Since the <code><var>thisArg</var></code> parameter (<code>this</code>) is provided to
-                            <code>forEach()</code>, it is passed to <code><var>callback</var></code> each time it's
-                            invoked. The callback uses it&nbsp;as its <code>this</code> value.</p>
+              <p>
+                Since the <code><var>thisArg</var></code> parameter
+                (<code>this</code>) is provided to <code>forEach()</code>, it is
+                passed to <code><var>callback</var></code> each time it's
+                invoked. The callback uses it&nbsp;as its
+                <code>this</code> value.
+              </p>
 
-                        <div class="note">
-                            <p><strong>Note:</strong> If passing the callback function uses an <a
-                                    href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">arrow function
-                                    expression</a>, the <code><var>thisArg</var></code> parameter can be omitted, since
-                                all arrow functions lexically bind the <a
-                                    href="/en-US/docs/Web/JavaScript/Reference/Operators/this"
-                                    title="A function's this keyword behaves a little differently in JavaScript compared to other languages. It also has some differences between strict mode and non-strict mode."><code>this</code></a>
-                                value.</p>
-                        </div>
+              <div class="note">
+                <p>
+                  <strong>Note:</strong> If passing the callback function uses
+                  an <a href="/">arrow function expression</a>, the
+                  <code><var>thisArg</var></code> parameter can be omitted,
+                  since all arrow functions lexically bind the
+                  <a
+                    href="/"
+                    title="A function's this keyword behaves a little differently in JavaScript compared to other languages. It also has some differences between strict mode and non-strict mode."
+                    ><code>this</code></a
+                  >
+                  value.
+                </p>
+              </div>
 
-                        <h3 id="An_object_copy_function">An object copy function</h3>
+              <h3 id="An_object_copy_function">An object copy function</h3>
 
-                        <p>The following code creates a copy of a given object.</p>
+              <p>The following code creates a copy of a given object.</p>
 
-                        <p>There are different ways to create a copy of an object. The following is just one way and is
-                            presented to explain how <code>Array.prototype.forEach()</code> works by using ECMAScript 5
-                            <code>Object.*</code> meta property functions.</p>
+              <p>
+                There are different ways to create a copy of an object. The
+                following is just one way and is presented to explain how
+                <code>Array.prototype.forEach()</code> works by using ECMAScript
+                5 <code>Object.*</code> meta property functions.
+              </p>
 
-                        <pre
-                            class="brush: js line-numbers language-js"><code class=" language-js"><span class="token keyword">function</span> <span class="token function">copy</span><span class="token punctuation">(</span><span class="token parameter">obj</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+              <pre
+                class="brush: js line-numbers language-js"
+              ><code class=" language-js"><span class="token keyword">function</span> <span class="token function">copy</span><span class="token punctuation">(</span><span class="token parameter">obj</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
   <span class="token keyword">const</span> copy <span class="token operator">=</span> Object<span class="token punctuation">.</span><span class="token function">create</span><span class="token punctuation">(</span>Object<span class="token punctuation">.</span><span class="token function">getPrototypeOf</span><span class="token punctuation">(</span>obj<span class="token punctuation">)</span><span class="token punctuation">)</span>
   <span class="token keyword">const</span> propNames <span class="token operator">=</span> Object<span class="token punctuation">.</span><span class="token function">getOwnPropertyNames</span><span class="token punctuation">(</span>obj<span class="token punctuation">)</span>
 
@@ -528,20 +870,34 @@ obj<span class="token punctuation">.</span>sum
 <span class="token keyword">const</span> obj2 <span class="token operator">=</span> <span class="token function">copy</span><span class="token punctuation">(</span>obj1<span class="token punctuation">)</span>      <span class="token comment">// obj2 looks like obj1 now</span>
 <span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
 
-                        <h3 id="If_the_array_is_modified_during_iteration_other_elements_might_be_skipped.">If the array
-                            is modified during iteration, other elements might be skipped.</h3>
+              <h3
+                id="If_the_array_is_modified_during_iteration_other_elements_might_be_skipped."
+              >
+                If the array is modified during iteration, other elements might
+                be skipped.
+              </h3>
 
-                        <p>The following example logs <code>"one"</code>, <code>"two"</code>, <code>"four"</code>.</p>
+              <p>
+                The following example logs <code>"one"</code>,
+                <code>"two"</code>, <code>"four"</code>.
+              </p>
 
-                        <p>When the entry containing the value <code>"two"</code> is reached, the first entry of the
-                            whole array is shifted off—resulting&nbsp;in all remaining entries moving up one position.
-                            Because element "four" is now at an earlier position in the array, <code>"three"</code> will
-                            be skipped.</p>
+              <p>
+                When the entry containing the value <code>"two"</code> is
+                reached, the first entry of the whole array is shifted
+                off—resulting&nbsp;in all remaining entries moving up one
+                position. Because element "four" is now at an earlier position
+                in the array, <code>"three"</code> will be skipped.
+              </p>
 
-                        <p><code>forEach()</code> does not make a copy of the array before iterating.</p>
+              <p>
+                <code>forEach()</code> does not make a copy of the array before
+                iterating.
+              </p>
 
-                        <pre
-                            class="brush:js line-numbers language-js"><code class=" language-js"><span class="token keyword">let</span> words <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token string">'one'</span><span class="token punctuation">,</span> <span class="token string">'two'</span><span class="token punctuation">,</span> <span class="token string">'three'</span><span class="token punctuation">,</span> <span class="token string">'four'</span><span class="token punctuation">]</span>
+              <pre
+                class="brush:js line-numbers language-js"
+              ><code class=" language-js"><span class="token keyword">let</span> words <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token string">'one'</span><span class="token punctuation">,</span> <span class="token string">'two'</span><span class="token punctuation">,</span> <span class="token string">'three'</span><span class="token punctuation">,</span> <span class="token string">'four'</span><span class="token punctuation">]</span>
 words<span class="token punctuation">.</span><span class="token function">forEach</span><span class="token punctuation">(</span><span class="token keyword">function</span><span class="token punctuation">(</span><span class="token parameter">word</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
   console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span>word<span class="token punctuation">)</span>
   <span class="token keyword">if</span> <span class="token punctuation">(</span>word <span class="token operator">===</span> <span class="token string">'two'</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
@@ -553,16 +909,23 @@ words<span class="token punctuation">.</span><span class="token function">forEac
 <span class="token comment">// four</span>
 <span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
 
-                        <h3 id="Flatten_an_array">Flatten an array</h3>
+              <h3 id="Flatten_an_array">Flatten an array</h3>
 
-                        <p>The following example is only here for learning purpose. If you want to flatten an array
-                            using built-in methods you can use <a
-                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat"
-                                title="The flat() method creates a new array with all sub-array elements concatenated into it recursively up to the specified depth."><code>Array.prototype.flat()</code></a>
-                            (which is expected to be part of ES2019, and is already implemented in some browsers).</p>
+              <p>
+                The following example is only here for learning purpose. If you
+                want to flatten an array using built-in methods you can use
+                <a
+                  href="/"
+                  title="The flat() method creates a new array with all sub-array elements concatenated into it recursively up to the specified depth."
+                  ><code>Array.prototype.flat()</code></a
+                >
+                (which is expected to be part of ES2019, and is already
+                implemented in some browsers).
+              </p>
 
-                        <pre
-                            class="brush: js line-numbers language-js"><code class=" language-js"><span class="token comment">/**
+              <pre
+                class="brush: js line-numbers language-js"
+              ><code class=" language-js"><span class="token comment">/**
  * Flattens passed array in one dimensional array
  *
  * @params {array} arr
@@ -578,7 +941,7 @@ words<span class="token punctuation">.</span><span class="token function">forEac
       result<span class="token punctuation">.</span><span class="token function">push</span><span class="token punctuation">(</span>i<span class="token punctuation">)</span>
     <span class="token punctuation">}</span>
   <span class="token punctuation">}</span><span class="token punctuation">)</span>
-  
+
   <span class="token keyword">return</span> result
 <span class="token punctuation">}</span>
 
@@ -588,18 +951,20 @@ words<span class="token punctuation">.</span><span class="token function">forEac
 <span class="token function">flatten</span><span class="token punctuation">(</span>problem<span class="token punctuation">)</span> <span class="token comment">// [1, 2, 3, 4, 5, 6, 7, 8, 9]</span>
 <span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
 
-                        <h2 id="Note_on_using_Promises_or_async_functions">Note on using Promises or async functions
-                        </h2>
+              <h2 id="Note_on_using_Promises_or_async_functions">
+                Note on using Promises or async functions
+              </h2>
 
-                        <pre
-                            class="brush: js line-numbers language-js"><code class=" language-js"><span class="token keyword">let</span> ratings <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token number">5</span><span class="token punctuation">,</span> <span class="token number">4</span><span class="token punctuation">,</span> <span class="token number">5</span><span class="token punctuation">]</span>
+              <pre
+                class="brush: js line-numbers language-js"
+              ><code class=" language-js"><span class="token keyword">let</span> ratings <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token number">5</span><span class="token punctuation">,</span> <span class="token number">4</span><span class="token punctuation">,</span> <span class="token number">5</span><span class="token punctuation">]</span>
 
 <span class="token keyword">let</span> sum <span class="token operator">=</span> <span class="token number">0</span>
 
 <span class="token keyword">let</span> <span class="token function-variable function">sumFunction</span> <span class="token operator">=</span> <span class="token keyword">async</span> <span class="token keyword">function</span> <span class="token punctuation">(</span><span class="token parameter">a<span class="token punctuation">,</span> b</span><span class="token punctuation">)</span>
 <span class="token punctuation">{</span>
     <span class="token keyword">return</span> a <span class="token operator">+</span> b
-<span class="token punctuation">}</span> 
+<span class="token punctuation">}</span>
 
 ratings<span class="token punctuation">.</span><span class="token function">forEach</span><span class="token punctuation">(</span><span class="token keyword">async</span> <span class="token keyword">function</span><span class="token punctuation">(</span><span class="token parameter">rating</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
     sum <span class="token operator">=</span> <span class="token keyword">await</span> <span class="token function">sumFunction</span><span class="token punctuation">(</span>sum<span class="token punctuation">,</span> rating<span class="token punctuation">)</span>
@@ -610,443 +975,760 @@ console<span class="token punctuation">.</span><span class="token function">log<
 <span class="token comment">// Actual output: 0</span>
 <span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
 
-                        <h2 id="Specifications">Specifications</h2>
+              <h2 id="Specifications">Specifications</h2>
 
-                        <table class="standard-table">
-                            <thead>
-                                <tr>
-                                    <th scope="col">Specification</th>
-                                    <th scope="col">Status</th>
-                                    <th scope="col">Comment</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td><a class="external" href="https://tc39.es/ecma262/#sec-array.prototype.foreach"
-                                            hreflang="en" rel="noopener" lang="en">ECMAScript Latest Draft
-                                            (ECMA-262)<br><small lang="en-US">The definition of
-                                                'Array.prototype.forEach' in that specification.</small></a></td>
-                                    <td><span class="spec-Draft">Draft</span></td>
-                                    <td></td>
-                                </tr>
-                                <tr>
-                                    <td><a class="external"
-                                            href="https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.foreach"
-                                            hreflang="en" rel="noopener" lang="en">ECMAScript 2015 (6th Edition,
-                                            ECMA-262)<br><small lang="en-US">The definition of 'Array.prototype.forEach'
-                                                in that specification.</small></a></td>
-                                    <td><span class="spec-Standard">Standard</span></td>
-                                    <td></td>
-                                </tr>
-                                <tr>
-                                    <td><a class="external"
-                                            href="https://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.18"
-                                            hreflang="en" rel="noopener" lang="en">ECMAScript 5.1 (ECMA-262)<br><small
-                                                lang="en-US">The definition of 'Array.prototype.forEach' in that
-                                                specification.</small></a></td>
-                                    <td><span class="spec-Standard">Standard</span></td>
-                                    <td>Initial definition. Implemented in JavaScript 1.6.</td>
-                                </tr>
-                            </tbody>
-                        </table>
+              <table class="standard-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Specification</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Comment</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <a
+                        class="external"
+                        href="https://tc39.es/ecma262/#sec-array.prototype.foreach"
+                        hreflang="en"
+                        rel="noopener"
+                        lang="en"
+                        >ECMAScript Latest Draft (ECMA-262)<br /><small
+                          lang="en-US"
+                          >The definition of 'Array.prototype.forEach' in that
+                          specification.</small
+                        ></a
+                      >
+                    </td>
+                    <td><span class="spec-Draft">Draft</span></td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a
+                        class="external"
+                        href="https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.foreach"
+                        hreflang="en"
+                        rel="noopener"
+                        lang="en"
+                        >ECMAScript 2015 (6th Edition, ECMA-262)<br /><small
+                          lang="en-US"
+                          >The definition of 'Array.prototype.forEach' in that
+                          specification.</small
+                        ></a
+                      >
+                    </td>
+                    <td><span class="spec-Standard">Standard</span></td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a
+                        class="external"
+                        href="https://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.18"
+                        hreflang="en"
+                        rel="noopener"
+                        lang="en"
+                        >ECMAScript 5.1 (ECMA-262)<br /><small lang="en-US"
+                          >The definition of 'Array.prototype.forEach' in that
+                          specification.</small
+                        ></a
+                      >
+                    </td>
+                    <td><span class="spec-Standard">Standard</span></td>
+                    <td>Initial definition. Implemented in JavaScript 1.6.</td>
+                  </tr>
+                </tbody>
+              </table>
 
-                        <h2 id="Browser_compatibility">Browser compatibility</h2>
+              <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-                        <div>
-                            <div class="hidden">The compatibility table in this page is generated from structured data.
-                                If you'd like to contribute to the data, please check out <a class="external"
-                                    href="https://github.com/mdn/browser-compat-data"
-                                    rel="noopener">https://github.com/mdn/browser-compat-data</a> and send us a pull
-                                request.</div>
+              <div>
+                <div class="hidden">
+                  The compatibility table in this page is generated from
+                  structured data. If you'd like to contribute to the data,
+                  please check out
+                  <a
+                    class="external"
+                    href="https://github.com/mdn/browser-compat-data"
+                    rel="noopener"
+                    >https://github.com/mdn/browser-compat-data</a
+                  >
+                  and send us a pull request.
+                </div>
 
-                            <div class="bc-data" id="bcd:javascript.builtins.Array.forEach"><a
-                                    class="bc-github-link external" href="https://github.com/mdn/browser-compat-data"
-                                    rel="noopener">Update compatibility data on GitHub</a>
-                                <table class="bc-table bc-table-js">
-                                    <thead>
-                                        <tr class="bc-platforms">
-                                            <td></td>
-                                            <th class="bc-platform-desktop" colspan="6"><span>Desktop</span></th>
-                                            <th class="bc-platform-mobile" colspan="6"><span>Mobile</span></th>
-                                            <th class="bc-platform-server" colspan="1"><span>Server</span></th>
-                                        </tr>
-                                        <tr class="bc-browsers">
-                                            <td></td>
-                                            <th class="bc-browser-chrome"><span
-                                                    class="bc-head-txt-label bc-head-icon-chrome">Chrome</span></th>
-                                            <th class="bc-browser-edge"><span
-                                                    class="bc-head-txt-label bc-head-icon-edge">Edge</span></th>
-                                            <th class="bc-browser-firefox"><span
-                                                    class="bc-head-txt-label bc-head-icon-firefox">Firefox</span></th>
-                                            <th class="bc-browser-ie"><span
-                                                    class="bc-head-txt-label bc-head-icon-ie">Internet Explorer</span>
-                                            </th>
-                                            <th class="bc-browser-opera"><span
-                                                    class="bc-head-txt-label bc-head-icon-opera">Opera</span></th>
-                                            <th class="bc-browser-safari"><span
-                                                    class="bc-head-txt-label bc-head-icon-safari">Safari</span></th>
-                                            <th class="bc-browser-webview_android"><span
-                                                    class="bc-head-txt-label bc-head-icon-webview_android">Android
-                                                    webview</span></th>
-                                            <th class="bc-browser-chrome_android"><span
-                                                    class="bc-head-txt-label bc-head-icon-chrome_android">Chrome for
-                                                    Android</span></th>
-                                            <th class="bc-browser-firefox_android"><span
-                                                    class="bc-head-txt-label bc-head-icon-firefox_android">Firefox for
-                                                    Android</span></th>
-                                            <th class="bc-browser-opera_android"><span
-                                                    class="bc-head-txt-label bc-head-icon-opera_android">Opera for
-                                                    Android</span></th>
-                                            <th class="bc-browser-safari_ios"><span
-                                                    class="bc-head-txt-label bc-head-icon-safari_ios">Safari on
-                                                    iOS</span></th>
-                                            <th class="bc-browser-samsunginternet_android"><span
-                                                    class="bc-head-txt-label bc-head-icon-samsunginternet_android">Samsung
-                                                    Internet</span></th>
-                                            <th class="bc-browser-nodejs"><span
-                                                    class="bc-head-txt-label bc-head-icon-nodejs">Node.js</span></th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr>
-                                            <th scope="row"><code>forEach</code></th>
-                                            <td class="bc-supports-yes bc-browser-chrome"><span
-                                                    class="bc-browser-name">Chrome</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                1</td>
-                                            <td class="bc-supports-yes bc-browser-edge"><span
-                                                    class="bc-browser-name">Edge</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                12</td>
-                                            <td class="bc-supports-yes bc-browser-firefox"><span
-                                                    class="bc-browser-name">Firefox</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                1.5</td>
-                                            <td class="bc-supports-yes bc-browser-ie"><span
-                                                    class="bc-browser-name">IE</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                9</td>
-                                            <td class="bc-supports-yes bc-browser-opera"><span
-                                                    class="bc-browser-name">Opera</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                Yes</td>
-                                            <td class="bc-supports-yes bc-browser-safari"><span
-                                                    class="bc-browser-name">Safari</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                3</td>
-                                            <td class="bc-supports-yes bc-browser-webview_android"><span
-                                                    class="bc-browser-name">WebView Android</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                ≤37</td>
-                                            <td class="bc-supports-yes bc-browser-chrome_android"><span
-                                                    class="bc-browser-name">Chrome Android</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                18</td>
-                                            <td class="bc-supports-yes bc-browser-firefox_android"><span
-                                                    class="bc-browser-name">Firefox Android</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                4</td>
-                                            <td class="bc-supports-yes bc-browser-opera_android"><span
-                                                    class="bc-browser-name">Opera Android</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                Yes</td>
-                                            <td class="bc-supports-yes bc-browser-safari_ios"><span
-                                                    class="bc-browser-name">Safari iOS</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                1</td>
-                                            <td class="bc-supports-yes bc-browser-samsunginternet_android"><span
-                                                    class="bc-browser-name">Samsung Internet Android</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                1.0</td>
-                                            <td class="bc-supports-yes bc-browser-nodejs"><span
-                                                    class="bc-browser-name">nodejs</span><abbr
-                                                    class="bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                </abbr>
-                                                Yes</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                                <div class="column-container bc-signal-block complete">
-                                    <div class="column-half left-block">
-                                        <div class="close-button-wrapper"><button class="button close-btn"></button>
-                                        </div>
-                                        <div class="complete-left-block-image" style="display: block;"></div>
-                                        <h2 class="complete-left-block-header">Thank you!</h2>
-                                    </div>
-                                    <div class="column-half right-block">
-                                        <h3 class="right-block-header"><span>Report sent</span></h3>
-                                        <div class="right-block-main-text">
-                                            <h4>What happens next?</h4>
-                                            <p>Our team will review your report. Once we verify the information you have
-                                                supplied we will update this browser compatability table accordingly.
-                                            </p>
-                                            <h4>Can I keep track of my report?</h4>
-                                            <p>You can join the GitHub repository to see updates and commits for this
-                                                table data:</p>
-                                            <p><a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data
-                                                    <span class="external external-icon"></span></a></p>
-                                        </div>
-                                        <div class="navigation-buttons"><button
-                                                class="button neutral main-btn">Finish</button></div>
-                                    </div>
+                <div class="bc-data" id="bcd:javascript.builtins.Array.forEach">
+                  <a
+                    class="bc-github-link external"
+                    href="https://github.com/mdn/browser-compat-data"
+                    rel="noopener"
+                    >Update compatibility data on GitHub</a
+                  >
+                  <table class="bc-table bc-table-js">
+                    <thead>
+                      <tr class="bc-platforms">
+                        <td></td>
+                        <th class="bc-platform-desktop" colspan="6">
+                          <span>Desktop</span>
+                        </th>
+                        <th class="bc-platform-mobile" colspan="6">
+                          <span>Mobile</span>
+                        </th>
+                        <th class="bc-platform-server" colspan="1">
+                          <span>Server</span>
+                        </th>
+                      </tr>
+                      <tr class="bc-browsers">
+                        <td></td>
+                        <th class="bc-browser-chrome">
+                          <span class="bc-head-txt-label bc-head-icon-chrome"
+                            >Chrome</span
+                          >
+                        </th>
+                        <th class="bc-browser-edge">
+                          <span class="bc-head-txt-label bc-head-icon-edge"
+                            >Edge</span
+                          >
+                        </th>
+                        <th class="bc-browser-firefox">
+                          <span class="bc-head-txt-label bc-head-icon-firefox"
+                            >Firefox</span
+                          >
+                        </th>
+                        <th class="bc-browser-ie">
+                          <span class="bc-head-txt-label bc-head-icon-ie"
+                            >Internet Explorer</span
+                          >
+                        </th>
+                        <th class="bc-browser-opera">
+                          <span class="bc-head-txt-label bc-head-icon-opera"
+                            >Opera</span
+                          >
+                        </th>
+                        <th class="bc-browser-safari">
+                          <span class="bc-head-txt-label bc-head-icon-safari"
+                            >Safari</span
+                          >
+                        </th>
+                        <th class="bc-browser-webview_android">
+                          <span
+                            class="bc-head-txt-label bc-head-icon-webview_android"
+                            >Android webview</span
+                          >
+                        </th>
+                        <th class="bc-browser-chrome_android">
+                          <span
+                            class="bc-head-txt-label bc-head-icon-chrome_android"
+                            >Chrome for Android</span
+                          >
+                        </th>
+                        <th class="bc-browser-firefox_android">
+                          <span
+                            class="bc-head-txt-label bc-head-icon-firefox_android"
+                            >Firefox for Android</span
+                          >
+                        </th>
+                        <th class="bc-browser-opera_android">
+                          <span
+                            class="bc-head-txt-label bc-head-icon-opera_android"
+                            >Opera for Android</span
+                          >
+                        </th>
+                        <th class="bc-browser-safari_ios">
+                          <span
+                            class="bc-head-txt-label bc-head-icon-safari_ios"
+                            >Safari on iOS</span
+                          >
+                        </th>
+                        <th class="bc-browser-samsunginternet_android">
+                          <span
+                            class="bc-head-txt-label bc-head-icon-samsunginternet_android"
+                            >Samsung Internet</span
+                          >
+                        </th>
+                        <th class="bc-browser-nodejs">
+                          <span class="bc-head-txt-label bc-head-icon-nodejs"
+                            >Node.js</span
+                          >
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <th scope="row"><code>forEach</code></th>
+                        <td class="bc-supports-yes bc-browser-chrome">
+                          <span class="bc-browser-name">Chrome</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          1
+                        </td>
+                        <td class="bc-supports-yes bc-browser-edge">
+                          <span class="bc-browser-name">Edge</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          12
+                        </td>
+                        <td class="bc-supports-yes bc-browser-firefox">
+                          <span class="bc-browser-name">Firefox</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          1.5
+                        </td>
+                        <td class="bc-supports-yes bc-browser-ie">
+                          <span class="bc-browser-name">IE</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          9
+                        </td>
+                        <td class="bc-supports-yes bc-browser-opera">
+                          <span class="bc-browser-name">Opera</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          Yes
+                        </td>
+                        <td class="bc-supports-yes bc-browser-safari">
+                          <span class="bc-browser-name">Safari</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          3
+                        </td>
+                        <td class="bc-supports-yes bc-browser-webview_android">
+                          <span class="bc-browser-name">WebView Android</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          ≤37
+                        </td>
+                        <td class="bc-supports-yes bc-browser-chrome_android">
+                          <span class="bc-browser-name">Chrome Android</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          18
+                        </td>
+                        <td class="bc-supports-yes bc-browser-firefox_android">
+                          <span class="bc-browser-name">Firefox Android</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          4
+                        </td>
+                        <td class="bc-supports-yes bc-browser-opera_android">
+                          <span class="bc-browser-name">Opera Android</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          Yes
+                        </td>
+                        <td class="bc-supports-yes bc-browser-safari_ios">
+                          <span class="bc-browser-name">Safari iOS</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          1
+                        </td>
+                        <td
+                          class="bc-supports-yes bc-browser-samsunginternet_android"
+                        >
+                          <span class="bc-browser-name"
+                            >Samsung Internet Android</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          1.0
+                        </td>
+                        <td class="bc-supports-yes bc-browser-nodejs">
+                          <span class="bc-browser-name">nodejs</span
+                          ><abbr
+                            class="bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                          </abbr>
+                          Yes
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <div class="column-container bc-signal-block complete">
+                    <div class="column-half left-block">
+                      <div class="close-button-wrapper">
+                        <button class="button close-btn"></button>
+                      </div>
+                      <div
+                        class="complete-left-block-image"
+                        style="display: block;"
+                      ></div>
+                      <h2 class="complete-left-block-header">Thank you!</h2>
+                    </div>
+                    <div class="column-half right-block">
+                      <h3 class="right-block-header">
+                        <span>Report sent</span>
+                      </h3>
+                      <div class="right-block-main-text">
+                        <h4>What happens next?</h4>
+                        <p>
+                          Our team will review your report. Once we verify the
+                          information you have supplied we will update this
+                          browser compatability table accordingly.
+                        </p>
+                        <h4>Can I keep track of my report?</h4>
+                        <p>
+                          You can join the GitHub repository to see updates and
+                          commits for this table data:
+                        </p>
+                        <p>
+                          <a href="https://github.com/mdn/browser-compat-data"
+                            >https://github.com/mdn/browser-compat-data
+                            <span class="external external-icon"></span
+                          ></a>
+                        </p>
+                      </div>
+                      <div class="navigation-buttons">
+                        <button class="button neutral main-btn">Finish</button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="column-container bc-signal-block">
+                    <div class="column-5 left-block">
+                      <div class="close-button-wrapper">
+                        <button class="button close-btn"></button>
+                      </div>
+                      <span class="left-block-image"></span>
+                      <h2 class="left-block-header">
+                        Tell us what’s wrong with this table
+                      </h2>
+                      <p>
+                        Our goal is to provide accurate, real values for all our
+                        compatibility data tables. Notifying MDN of inaccurate
+                        data or supplying new data pushes us further towards our
+                        goal of providing 100% real values to the developer
+                        community.<br />Thank you for helping.
+                      </p>
+                    </div>
+                    <div class="column-7 right-block form-control-block">
+                      <h3 class="highlight-spanned">
+                        <span class="highlight-span"></span>
+                      </h3>
+                      <div class="inner-step" id="step-1">
+                        <div class="controls">
+                          <div class="control">
+                            <span class="step-num">1</span>
+                            <div class="control-wrap">
+                              <div class="control-header">
+                                <span class="step-num inline">1</span>Which
+                                browsers are affected?
+                              </div>
+                              <div class="control-description">
+                                Please select the browser or browsers which are
+                                affected.
+                              </div>
+                              <div class="select-browser-block">
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/chrome.b49946f7739f.svg"
+                                      alt="Chrome"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+                                  <div class="browser-name">Chrome</div>
                                 </div>
-                                <div class="column-container bc-signal-block">
-                                    <div class="column-5 left-block">
-                                        <div class="close-button-wrapper"><button class="button close-btn"></button>
-                                        </div><span class="left-block-image"></span>
-                                        <h2 class="left-block-header">Tell us what’s wrong with this table</h2>
-                                        <p>Our goal is to provide accurate, real values for all our compatibility data
-                                            tables. Notifying MDN of inaccurate data or supplying new data pushes us
-                                            further towards our goal of providing 100% real values to the developer
-                                            community.<br>Thank you for helping.</p>
-                                    </div>
-                                    <div class="column-7 right-block form-control-block">
-                                        <h3 class="highlight-spanned"><span class="highlight-span"></span></h3>
-                                        <div class="inner-step" id="step-1">
-                                            <div class="controls">
-                                                <div class="control"><span class="step-num">1</span>
-                                                    <div class="control-wrap">
-                                                        <div class="control-header"><span
-                                                                class="step-num inline">1</span>Which browsers are
-                                                            affected?</div>
-                                                        <div class="control-description">Please select the browser or
-                                                            browsers which are affected.</div>
-                                                        <div class="select-browser-block">
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/chrome.b49946f7739f.svg"
-                                                                        alt="Chrome" role="img" aria-hidden="true">
-                                                                </div>
-                                                                <div class="browser-name">Chrome</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/edge.a5b352eb863f.svg"
-                                                                        alt="Edge" role="img" aria-hidden="true"></div>
-                                                                <div class="browser-name">Edge</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/firefox.1c9f202ae696.svg"
-                                                                        alt="Firefox" role="img" aria-hidden="true">
-                                                                </div>
-                                                                <div class="browser-name">Firefox</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/internet-explorer.4bb2b5f99e82.svg"
-                                                                        alt="Internet Explorer" role="img"
-                                                                        aria-hidden="true"></div>
-                                                                <div class="browser-name">Internet Explorer</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/opera.da441711d2f6.svg"
-                                                                        alt="Opera" role="img" aria-hidden="true"></div>
-                                                                <div class="browser-name">Opera</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/safari.aca6ae03b671.svg"
-                                                                        alt="Safari" role="img" aria-hidden="true">
-                                                                </div>
-                                                                <div class="browser-name">Safari</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/platforms/android.201ce5d041f7.svg"
-                                                                        alt="Android webview" role="img"
-                                                                        aria-hidden="true"></div>
-                                                                <div class="browser-name">Android webview</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/chrome.b49946f7739f.svg"
-                                                                        alt="Chrome for Android" role="img"
-                                                                        aria-hidden="true"></div>
-                                                                <div class="browser-name">Chrome for Android</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/firefox.1c9f202ae696.svg"
-                                                                        alt="Firefox for Android" role="img"
-                                                                        aria-hidden="true"></div>
-                                                                <div class="browser-name">Firefox for Android</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/opera.da441711d2f6.svg"
-                                                                        alt="Opera for Android" role="img"
-                                                                        aria-hidden="true"></div>
-                                                                <div class="browser-name">Opera for Android</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/safari.aca6ae03b671.svg"
-                                                                        alt="Safari on iOS" role="img"
-                                                                        aria-hidden="true"></div>
-                                                                <div class="browser-name">Safari on iOS</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/browsers/samsung-internet.8faa2ee1b8a1.svg"
-                                                                        alt="Samsung Internet" role="img"
-                                                                        aria-hidden="true"></div>
-                                                                <div class="browser-name">Samsung Internet</div>
-                                                            </div>
-                                                            <div class="browser">
-                                                                <div class="browser-logo"><span
-                                                                        class="browser-selected-icon"></span><img
-                                                                        src="https://developer.mozilla.org/static/platforms/nodejs.33dfe169dc5c.svg"
-                                                                        alt="Node.js" role="img" aria-hidden="true">
-                                                                </div>
-                                                                <div class="browser-name">Node.js</div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="control"><span class="step-num">2</span>
-                                                    <div class="control-wrap">
-                                                        <div class="control-header has-control"><span
-                                                                class="step-num inline">2</span>Which table row is
-                                                            affected?<span class="select-wrapper"><select
-                                                                    id="select-row">
-                                                                    <option value="forEach">forEach</option>
-                                                                </select></span></div>
-                                                        <div class="control-description"></div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="navigation-buttons reverse mob-reduced-space"><button
-                                                    class="button neutral disabled next-step-btn">Next step (2 of
-                                                    2)<span class="icon-next"></span></button></div>
-                                        </div>
-                                        <div id="step-2" class="inner-step">
-                                            <div class="controls">
-                                                <div class="control"><span class="step-num">3</span>
-                                                    <div class="control-wrap">
-                                                        <div class="control-header with-optional-label"><span
-                                                                class="step-num inline">3</span>Can you provide a brief
-                                                            explanation?</div>
-                                                        <div class="control-description">Briefly outline the issue you
-                                                            are highlighting.</div><textarea class="control-input"
-                                                            id="brief-explanation" maxlength="1000"></textarea>
-                                                    </div>
-                                                </div>
-                                                <div class="control"><span class="step-num">4</span>
-                                                    <div class="control-wrap">
-                                                        <div class="control-header with-optional-label"><span
-                                                                class="step-num inline">4</span>Do you have any
-                                                            supporting material?<span
-                                                                class="optional-text">Optional</span></div>
-                                                        <div class="control-description">Browser documentation and
-                                                            release notes are good supporting items to accompany your
-                                                            message. A demo hosted on services like Codepen or JSBin are
-                                                            perfect for providing real examples of your findings.</div>
-                                                        <textarea class="control-input" id="supporting-material"
-                                                            maxlength="1000"></textarea>
-                                                    </div>
-                                                </div>
-                                                <div class="warning error-message"><span class="error-label">Connection
-                                                        error:</span><span>Sorry, we can’t seem to reach the server. We
-                                                        are working to fix the problem. Please try again later.</span>
-                                                </div>
-                                            </div>
-                                            <div class="navigation-buttons reverse"><button
-                                                    class="button neutral disabled main-btn scroll-to-signal">Send
-                                                    report</button><button class="button prev-step-btn btn-dark"><span
-                                                        class="icon-back"></span>Previous step</button></div>
-                                        </div>
-                                    </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/edge.a5b352eb863f.svg"
+                                      alt="Edge"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">Edge</div>
                                 </div>
-                                <div class="signal-link-ext-container">
-                                    <div class="signal-link-container">
-                                        <hr><a class="scroll-to-signal" href="#">What are we missing?</a></div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/firefox.1c9f202ae696.svg"
+                                      alt="Firefox"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+                                  <div class="browser-name">Firefox</div>
                                 </div>
-                                <section class="bc-legend" id="sect1">
-                                    <h3 class="offscreen" id="Legend">Legend</h3>
-                                    <dl>
-                                        <dt><span class="bc-supports-yes bc-supports">
-                                                <abbr class="bc-level bc-level-yes only-icon" title="Full support">
-                                                    <span>Full support</span>
-                                                    &nbsp;
-                                                </abbr></span></dt>
-                                        <dd>Full support</dd>
-                                    </dl>
-                                </section>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/internet-explorer.4bb2b5f99e82.svg"
+                                      alt="Internet Explorer"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">
+                                    Internet Explorer
+                                  </div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/opera.da441711d2f6.svg"
+                                      alt="Opera"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">Opera</div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/safari.aca6ae03b671.svg"
+                                      alt="Safari"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+                                  <div class="browser-name">Safari</div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/platforms/android.201ce5d041f7.svg"
+                                      alt="Android webview"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">
+                                    Android webview
+                                  </div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/chrome.b49946f7739f.svg"
+                                      alt="Chrome for Android"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">
+                                    Chrome for Android
+                                  </div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/firefox.1c9f202ae696.svg"
+                                      alt="Firefox for Android"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">
+                                    Firefox for Android
+                                  </div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/opera.da441711d2f6.svg"
+                                      alt="Opera for Android"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">
+                                    Opera for Android
+                                  </div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/safari.aca6ae03b671.svg"
+                                      alt="Safari on iOS"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">Safari on iOS</div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/browsers/samsung-internet.8faa2ee1b8a1.svg"
+                                      alt="Samsung Internet"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+
+                                  <div class="browser-name">
+                                    Samsung Internet
+                                  </div>
+                                </div>
+                                <div class="browser">
+                                  <div class="browser-logo">
+                                    <span class="browser-selected-icon"></span
+                                    ><img
+                                      src="https://developer.mozilla.org/static/platforms/nodejs.33dfe169dc5c.svg"
+                                      alt="Node.js"
+                                      role="img"
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+                                  <div class="browser-name">Node.js</div>
+                                </div>
+                              </div>
                             </div>
+                          </div>
+                          <div class="control">
+                            <span class="step-num">2</span>
+                            <div class="control-wrap">
+                              <div class="control-header has-control">
+                                <span class="step-num inline">2</span>Which
+                                table row is affected?<span
+                                  class="select-wrapper"
+                                  ><select id="select-row">
+                                    <option value="forEach">forEach</option>
+                                  </select></span
+                                >
+                              </div>
+                              <div class="control-description"></div>
+                            </div>
+                          </div>
                         </div>
+                        <div
+                          class="navigation-buttons reverse mob-reduced-space"
+                        >
+                          <button class="button neutral disabled next-step-btn">
+                            Next step (2 of 2)<span class="icon-next"></span>
+                          </button>
+                        </div>
+                      </div>
+                      <div id="step-2" class="inner-step">
+                        <div class="controls">
+                          <div class="control">
+                            <span class="step-num">3</span>
+                            <div class="control-wrap">
+                              <div class="control-header with-optional-label">
+                                <span class="step-num inline">3</span>Can you
+                                provide a brief explanation?
+                              </div>
+                              <div class="control-description">
+                                Briefly outline the issue you are highlighting.
+                              </div>
+                              <textarea
+                                class="control-input"
+                                id="brief-explanation"
+                                maxlength="1000"
+                              ></textarea>
+                            </div>
+                          </div>
+                          <div class="control">
+                            <span class="step-num">4</span>
+                            <div class="control-wrap">
+                              <div class="control-header with-optional-label">
+                                <span class="step-num inline">4</span>Do you
+                                have any supporting material?<span
+                                  class="optional-text"
+                                  >Optional</span
+                                >
+                              </div>
+                              <div class="control-description">
+                                Browser documentation and release notes are good
+                                supporting items to accompany your message. A
+                                demo hosted on services like Codepen or JSBin
+                                are perfect for providing real examples of your
+                                findings.
+                              </div>
+                              <textarea
+                                class="control-input"
+                                id="supporting-material"
+                                maxlength="1000"
+                              ></textarea>
+                            </div>
+                          </div>
+                          <div class="warning error-message">
+                            <span class="error-label">Connection error:</span
+                            ><span
+                              >Sorry, we can’t seem to reach the server. We are
+                              working to fix the problem. Please try again
+                              later.</span
+                            >
+                          </div>
+                        </div>
+                        <div class="navigation-buttons reverse">
+                          <button
+                            class="button neutral disabled main-btn scroll-to-signal"
+                          >
+                            Send report</button
+                          ><button class="button prev-step-btn btn-dark">
+                            <span class="icon-back"></span>Previous step
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="signal-link-ext-container">
+                    <div class="signal-link-container">
+                      <hr />
+                      <a class="scroll-to-signal" href="#"
+                        >What are we missing?</a
+                      >
+                    </div>
+                  </div>
+                  <section class="bc-legend" id="sect1">
+                    <h3 class="offscreen" id="Legend">Legend</h3>
+                    <dl>
+                      <dt>
+                        <span class="bc-supports-yes bc-supports">
+                          <abbr
+                            class="bc-level bc-level-yes only-icon"
+                            title="Full support"
+                          >
+                            <span>Full support</span>
+                            &nbsp;
+                          </abbr></span
+                        >
+                      </dt>
+                      <dd>Full support</dd>
+                    </dl>
+                  </section>
+                </div>
+              </div>
 
-                        <h2 id="See_also">See also</h2>
+              <h2 id="See_also">See also</h2>
 
-                        <ul>
-                            <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find"
-                                    title="The find() method returns the value of the first element in the provided array that satisfies the provided testing function."><code>Array.prototype.find()</code></a>
-                            </li>
-                            <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex"
-                                    title="The findIndex() method returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating that no element passed the test."><code>Array.prototype.findIndex()</code></a>
-                            </li>
-                            <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map"
-                                    title="The map() method creates a new array with the results of calling a provided function on every element in the calling&nbsp;array."><code>Array.prototype.map()</code></a>
-                            </li>
-                            <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter"
-                                    title="The filter() method creates a new array with all elements that pass the test implemented by the provided function."><code>Array.prototype.filter()</code></a>
-                            </li>
-                            <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every"
-                                    title="The every() method tests whether all elements in the array pass the test implemented by the provided function. It returns a Boolean value."><code>Array.prototype.every()</code></a>
-                            </li>
-                            <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some"
-                                    title="The some() method tests whether at least one&nbsp;element in the array passes the test implemented by the provided function. It returns a Boolean value."><code>Array.prototype.some()</code></a>
-                            </li>
-                            <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach"
-                                    title="The forEach() method executes a provided function once per each key/value pair in the Map object, in insertion order."><code>Map.prototype.forEach()</code></a>
-                            </li>
-                            <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach"
-                                    title="The forEach() method executes a provided function once for each value in the Set object, in insertion order."><code>Set.prototype.forEach()</code></a>
-                            </li>
-                        </ul>
+              <ul>
+                <li>
+                  <a
+                    href="/"
+                    title="The find() method returns the value of the first element in the provided array that satisfies the provided testing function."
+                    ><code>Array.prototype.find()</code></a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="/"
+                    title="The findIndex() method returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating that no element passed the test."
+                    ><code>Array.prototype.findIndex()</code></a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="/"
+                    title="The map() method creates a new array with the results of calling a provided function on every element in the calling&nbsp;array."
+                    ><code>Array.prototype.map()</code></a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="/"
+                    title="The filter() method creates a new array with all elements that pass the test implemented by the provided function."
+                    ><code>Array.prototype.filter()</code></a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="/"
+                    title="The every() method tests whether all elements in the array pass the test implemented by the provided function. It returns a Boolean value."
+                    ><code>Array.prototype.every()</code></a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="/"
+                    title="The some() method tests whether at least one&nbsp;element in the array passes the test implemented by the provided function. It returns a Boolean value."
+                    ><code>Array.prototype.some()</code></a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="/"
+                    title="The forEach() method executes a provided function once per each key/value pair in the Map object, in insertion order."
+                    ><code>Map.prototype.forEach()</code></a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="/"
+                    title="The forEach() method executes a provided function once for each value in the Set object, in insertion order."
+                    ><code>Set.prototype.forEach()</code></a
+                  >
+                </li>
+              </ul>
 
-                        <h3 id="sparseArray" name="sparseArray">Polyfill</h3>
+              <h3 id="sparseArray" name="sparseArray">Polyfill</h3>
 
-                        <pre
-                            class="line-numbers language-html"><code class=" language-html">//https://raw.githubusercontent.com/FabioVergani/js-Polyfill_forEach/master/forEach.js
+              <pre
+                class="line-numbers language-html"
+              ><code class=" language-html">//https://raw.githubusercontent.com/FabioVergani/js-Polyfill_forEach/master/forEach.js
 
 (function(){
 	var o=[];
@@ -1091,510 +1773,998 @@ console<span class="token punctuation">.</span><span class="token function">log<
 	//3,2,[1, 2, 3],{0:1,1:2,2:3}
 
 */<span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></span></code></pre>
-
-                    </article>
-                    <div class="metadata">
-                        <section class="document-meta">
-                            <header class="visually-hidden">
-                                <h4>Metadata</h4>
-                            </header>
-                            <ul>
-                                <li class="last-modified"><b>Last modified:</b> <time
-                                        datetime="2019-12-25T10:51:18.956137">Dec 25, 2019</time>,
-                                    <!-- --> <a
-                                        href="https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach$history"
-                                        rel="nofollow">by MDN contributors</a></li>
-                            </ul>
-                        </section>
-                    </div>
-                </div>
-                <div class="sidebar">
-                    <div class="quick-links">
-                        <div class="quick-links-head sidebar-heading">Related Topics</div>
-                        <div>
-                            <ol>
-                                <li><strong><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects">Standard
-                                            built-in objects</a></strong></li>
-                                <li><strong><a
-                                            href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a></strong>
-                                </li>
-                                <li data-default-state="open"><a href="#"><strong>Properties</strong></a>
-                                    <ol>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length"
-                                                title="The length property of an object which is an instance of type Array sets or returns the number of elements in that array. The value is an unsigned, 32-bit integer that is always numerically greater than the highest index in the array."><code>Array.length</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables"
-                                                title="The @@unscopable symbol property contains property names that were not included in the ECMAScript standard prior to the ES2015 version. These properties are excluded from with statement bindings."><code>Array.prototype[@@unscopables]</code></a>
-                                        </li>
-                                    </ol>
-                                </li>
-                                <li data-default-state="open"><a href="#"><strong>Methods</strong></a>
-                                    <ol>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from"
-                                                title="The Array.from() method creates a new, shallow-copied Array instance from an array-like or iterable object."><code>Array.from()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray"
-                                                title="The Array.isArray()&nbsp;method&nbsp;determines whether the passed value is an Array."><code>Array.isArray()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/observe"
-                                                    title="The Array.observe() method was used for asynchronously observing changes to Arrays, similar to Object.observe() for objects. It provided a stream of changes in order of occurrence. It's equivalent to Object.observe() invoked with the accept type list [&quot;add&quot;, &quot;update&quot;, &quot;delete&quot;, &quot;splice&quot;]. However, this API has been deprecated and removed from Browsers. You can use the more general Proxy object instead."><code>Array.observe()</code></a></s>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of"
-                                                title="The Array.of() method creates a new Array instance from a variable number of arguments, regardless of number or type of the arguments."><code>Array.of()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat"
-                                                title="The concat() method is used to merge two or more arrays. This method does not change the existing arrays, but instead returns a new array."><code>Array.prototype.concat()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin"
-                                                title="The copyWithin() method shallow copies part of an array to another location in the same array and returns it&nbsp;without modifying its length."><code>Array.prototype.copyWithin()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/entries"
-                                                title="The entries() method returns a new Array Iterator object that contains the key/value pairs for each index in the array."><code>Array.prototype.entries()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every"
-                                                title="The every() method tests whether all elements in the array pass the test implemented by the provided function. It returns a Boolean value."><code>Array.prototype.every()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill"
-                                                title="The fill() method changes all elements in an array to a static value, from a start index&nbsp;(default 0) to an end index&nbsp;(default array.length). It returns the modified array."><code>Array.prototype.fill()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter"
-                                                title="The filter() method creates a new array with all elements that pass the test implemented by the provided function."><code>Array.prototype.filter()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find"
-                                                title="The find() method returns the value of the first element in the provided array that satisfies the provided testing function."><code>Array.prototype.find()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex"
-                                                title="The findIndex() method returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating that no element passed the test."><code>Array.prototype.findIndex()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat"
-                                                title="The flat() method creates a new array with all sub-array elements concatenated into it recursively up to the specified depth."><code>Array.prototype.flat()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap"
-                                                title="The flatMap() method first maps each element using a mapping function, then flattens the result into a new array. It is identical to a map() followed by a flat() of depth 1, but flatMap() is often quite useful, as merging both into one method is slightly more efficient."><code>Array.prototype.flatMap()</code></a>
-                                        </li>
-                                        <li><em><code>Array.prototype.forEach()</code></em></li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes"
-                                                title="The includes() method determines whether an array includes a certain value among its entries, returning true or false as appropriate."><code>Array.prototype.includes()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf"
-                                                title="The indexOf() method returns the first index at which a given element can be found in the array, or -1 if it is not present."><code>Array.prototype.indexOf()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join"
-                                                title="The join() method creates and returns a new string by concatenating all of the elements in an array (or an array-like object), separated by commas or a specified separator string. If the array has only one item, then that item will be returned without using the separator."><code>Array.prototype.join()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/keys"
-                                                title="The keys() method returns a new Array Iterator object that contains the keys for each index in the array."><code>Array.prototype.keys()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf"
-                                                title="The lastIndexOf() method returns the last index at which a given element can be found in the array, or -1 if it is not present. The array is searched backwards, starting at fromIndex."><code>Array.prototype.lastIndexOf()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map"
-                                                title="The map() method creates a new array with the results of calling a provided function on every element in the calling&nbsp;array."><code>Array.prototype.map()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop"
-                                                title="The pop() method removes the last element from an array and returns that element. This method changes the length of the array."><code>Array.prototype.pop()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push"
-                                                title="The push() method adds one or more elements to the end of an array and returns the new length of the array."><code>Array.prototype.push()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce"
-                                                title="The reduce() method executes a reducer function (that you provide) on each element of the array, resulting in a single output value."><code>Array.prototype.reduce()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/ReduceRight"
-                                                title="The reduceRight() method applies a function against an accumulator and each value of the array (from right-to-left) to reduce it to a single value."><code>Array.prototype.reduceRight()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse"
-                                                title="The reverse() method reverses an array in place. The first array element becomes the last, and the last array element becomes the first."><code>Array.prototype.reverse()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift"
-                                                title="The shift() method removes the first element from an array and returns that removed element. This method changes the length of the array."><code>Array.prototype.shift()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice"
-                                                title="The slice() method returns a shallow copy of a portion of an array into a new array object selected from begin to end (end not included) where begin and end represent the index of items in that array. The original array will not be modified."><code>Array.prototype.slice()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some"
-                                                title="The some() method tests whether at least one&nbsp;element in the array passes the test implemented by the provided function. It returns a Boolean value."><code>Array.prototype.some()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort"
-                                                title="The sort() method sorts the elements of an array in place and returns the sorted array. The default sort order is ascending, built upon converting the elements into strings, then comparing their sequences of UTF-16 code units values."><code>Array.prototype.sort()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice"
-                                                title="The splice() method changes the contents of an array by removing or replacing existing elements and/or adding new elements in place."><code>Array.prototype.splice()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString"
-                                                title="The toLocaleString() method returns a string representing the elements of the array. The elements are converted to Strings using their toLocaleString methods and these Strings are separated by a locale-specific String (such as a comma “,”)."><code>Array.prototype.toLocaleString()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSource"
-                                                title="The toSource() method returns a string representing the source code of the array."><code>Array.prototype.toSource()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString"
-                                                title="The toString() method returns a string representing the specified array and its elements."><code>Array.prototype.toString()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift"
-                                                title="The unshift() method adds one or more elements to the beginning of an array and returns the new length of the array."><code>Array.prototype.unshift()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/values"
-                                                title="The values() method returns a new Array Iterator object that contains the values for each index in the array."><code>Array.prototype.values()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator"
-                                                title="The initial value of the @@iterator property is the same function object as the initial value of the values() property."><code>Array.prototype[@@iterator]()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unobserve"
-                                                    title="The Array.unobserve() method was used to remove observers set by Array.observe(), but has been deprecated and removed from Browsers. You can use the more general Proxy object instead."><code>Array.unobserve()</code></a></s>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species"
-                                                title="The Array[@@species] accessor property returns the Array constructor."><code>get Array[@@species]</code></a>
-                                        </li>
-                                    </ol>
-                                </li>
-                                <li><strong>Inheritance:</strong></li>
-                                <li><strong><a
-                                            href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function"><code>Function</code></a></strong>
-                                </li>
-                                <li><a href="#"><strong>Properties</strong></a>
-                                    <ol>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This deprecated API should no longer be used, but will probably still work."><i
-                                                        class="icon-thumbs-down-alt"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments"
-                                                title="The function.arguments property refers to an an array-like object corresponding to the arguments passed to a function. Use the simple variable arguments instead. This property is forbidden in strict mode."><code>Function.arguments</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arity"
-                                                    title="Implemented in JavaScript 1.2. Deprecated in JavaScript 1.4."><code>Function.arity</code></a></s>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller"
-                                                title="The function.caller property returns the function that invoked the specified function. This property is forbidden in strict mode."><code>Function.caller</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName"
-                                                title="The function.displayName property returns the display name of the function."><code>Function.displayName</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length"
-                                                title="The length property indicates&nbsp;the number of parameters expected by the function."><code>Function.length</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name"
-                                                title="A Function object's read-only name property indicates the function's name as specified when it was created, or it may be rather&nbsp;anonymous&nbsp;or ''(an empty string)&nbsp;for functions created anonymously."><code>Function.name</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype"
-                                                title="The Function.prototype property represents the Function prototype object."><code>Function.prototype</code></a>
-                                        </li>
-                                    </ol>
-                                </li>
-                                <li><a href="#"><strong>Methods</strong></a>
-                                    <ol>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply"
-                                                title="The apply() method calls a function with a given this value, and arguments provided as an array (or an array-like object)."><code>Function.prototype.apply()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind"
-                                                title="The bind() method creates a new function that, when called, has its this keyword set to the provided value, with a given sequence of arguments preceding any provided when the new function is called."><code>Function.prototype.bind()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call"
-                                                title="The call() method calls a function with a given this value and arguments provided individually."><code>Function.prototype.call()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><span
-                                                class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/isGenerator"
-                                                    title="The non-standard isGenerator() method used to determine whether or not a function is a generator. It has been removed from Firefox starting with version 58."><code>Function.prototype.isGenerator()</code></a></s>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toSource"
-                                                title="The toSource() method returns a string representing the source code of the object."><code>Function.prototype.toSource()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString"
-                                                title="The toString() method returns a string representing the source code of the function."><code>Function.prototype.toString()</code></a>
-                                        </li>
-                                    </ol>
-                                </li>
-                                <li><strong><a
-                                            href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object"><code>Object</code></a></strong>
-                                </li>
-                                <li><a href="#"><strong>Properties</strong></a>
-                                    <ol>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><span
-                                                class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/count"
-                                                    title="The __count__ property used to store the count of enumerable properties on the object, but it has been removed."><code>Object.prototype.__count__</code></a></s>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><span
-                                                class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/noSuchMethod"
-                                                    title="The __noSuchMethod__ property used to reference a function to be executed when a non-existent method is called on an object, but this function is no longer available."><code>Object.prototype.__noSuchMethod__</code></a></s>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><span
-                                                class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/Parent"
-                                                    title="The __parent__ property used to point to an object's context, but it has been removed."><code>Object.prototype.__parent__</code></a></s>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This deprecated API should no longer be used, but will probably still work."><i
-                                                        class="icon-thumbs-down-alt"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto"
-                                                title="The __proto__ property of Object.prototype is an accessor property (a getter function and a setter function) that exposes the internal [[Prototype]] (either an object or null) of the object through which it is accessed."><code>Object.prototype.__proto__</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor"
-                                                title="The constructor property returns a reference to the Object constructor function that created the instance object. Note that the value of this property is a reference to the function itself, not a string containing the function's name."><code>Object.prototype.constructor</code></a>
-                                        </li>
-                                    </ol>
-                                </li>
-                                <li><a href="#"><strong>Methods</strong></a>
-                                    <ol>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This deprecated API should no longer be used, but will probably still work."><i
-                                                        class="icon-thumbs-down-alt"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__"
-                                                title="The __defineGetter__ method binds an object's property to a function to be called when that property is looked up."><code>Object.prototype.__defineGetter__()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This deprecated API should no longer be used, but will probably still work."><i
-                                                        class="icon-thumbs-down-alt"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__"
-                                                title="The __defineSetter__ method binds an object's property to a function to be called when an attempt is made to set that property."><code>Object.prototype.__defineSetter__()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This deprecated API should no longer be used, but will probably still work."><i
-                                                        class="icon-thumbs-down-alt"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__"
-                                                title="The __lookupGetter__ method returns the function bound as a getter to the specified property."><code>Object.prototype.__lookupGetter__()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This deprecated API should no longer be used, but will probably still work."><i
-                                                        class="icon-thumbs-down-alt"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__"
-                                                title="The __lookupSetter__ method returns the function bound as a setter to the specified property."><code>Object.prototype.__lookupSetter__()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty"
-                                                title="The hasOwnProperty() method returns a boolean indicating whether the object has the specified property as its own property (as opposed to inheriting it)."><code>Object.prototype.hasOwnProperty()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf"
-                                                title="The isPrototypeOf() method checks if an object exists in another object's prototype chain."><code>Object.prototype.isPrototypeOf()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable"
-                                                title="The propertyIsEnumerable() method returns a Boolean indicating whether the specified property is enumerable and is the object's own property."><code>Object.prototype.propertyIsEnumerable()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString"
-                                                title="The toLocaleString() method returns a string representing the object. This method is meant to be overridden by derived objects for locale-specific purposes."><code>Object.prototype.toLocaleString()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This API has not been standardized."><i
-                                                        class="icon-warning-sign"> </i></span></span><a
-                                                href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource"
-                                                title="The toSource() method returns a string representing the source code of the object."><code>Object.prototype.toSource()</code></a>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString"
-                                                title="The toString() method returns a string representing the object."><code>Object.prototype.toString()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This deprecated API should no longer be used, but will probably still work."><i
-                                                        class="icon-thumbs-down-alt"> </i></span></span><span
-                                                class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch"
-                                                    title="The unwatch() method removes a watchpoint set with the watch() method."><code>Object.prototype.unwatch()</code></a></s>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf"
-                                                title="The valueOf() method returns the primitive value of the specified object."><code>Object.prototype.valueOf()</code></a>
-                                        </li>
-                                        <li><span class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This deprecated API should no longer be used, but will probably still work."><i
-                                                        class="icon-thumbs-down-alt"> </i></span></span><span
-                                                class="sidebar-icon"><span class="icon-only-inline"
-                                                    title="This is an obsolete API and is no longer guaranteed to work."><i
-                                                        class="icon-trash"> </i></span></span><s
-                                                class="obsoleteElement"><a
-                                                    href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch"
-                                                    title="The watch() method watches for a property to be assigned a value and runs a function when that occurs."><code>Object.prototype.watch()</code></a></s>
-                                        </li>
-                                        <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf"
-                                                title="The Object.setPrototypeOf() method sets the prototype (i.e., the internal [[Prototype]] property) of a specified object to another object or null."><code>Object.setPrototypeOf()</code></a>
-                                        </li>
-                                    </ol>
-                                </li>
-                            </ol>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </main>
-        <section class="newsletter-container">
-            <div id="newsletter-form-container" class="newsletter">
-                <form class="newsletter-form nodisable" name="newsletter-form">
-                    <section class="newsletter-head">
-                        <h2 class="newsletter-teaser">Learn the best of web development</h2>
-                        <p class="newsletter-description">Get the latest and greatest from MDN delivered straight to
-                            your inbox.</p>
-                        <p class="hidden" aria-hidden="true">The newsletter is offered in English only at the moment.
-                        </p>
-                    </section>
-                    <fieldset class="newsletter-fields"><input type="hidden" name="fmt" value="H"><input type="hidden"
-                            name="newsletters" value="app-dev">
-                        <div class="form-group newsletter-group-email"><label for="newsletter-email-input"
-                                class="form-label offscreen">E-mail</label><input type="email"
-                                id="newsletter-email-input" name="email" class="form-input newsletter-input-email"
-                                placeholder="you@example.com" required=""></div>
-                        <div id="newsletter-privacy" class="hidden" aria-hidden="true"><input type="checkbox"
-                                id="newsletter-privacy-input" name="privacy" required=""><label
-                                for="newsletter-privacy-input">I’m okay with Mozilla handling my info as explained in
-                                this <a href="https://www.mozilla.org/privacy/">Privacy Policy</a>.</label></div>
-                        <div class="newsletter-group-submit"><button id="newsletter-submit" type="submit"
-                                class="button neutral newsletter-submit">Sign up now</button></div>
-                    </fieldset>
-                </form><button type="button" class="only-icon newsletter-hide"
-                    aria-controls="newsletter-form-container"><span>Hide Newsletter Sign-up</span><svg
-                        class="icon icon-close" xmlns="http://www.w3.org/2000/svg" role="presentation"
-                        viewBox="0 0 24 28">
-                        <path
-                            d="M20.281 20.656c0 .391-.156.781-.438 1.062l-2.125 2.125c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438L11 19.249l-4.594 4.594c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438l-2.125-2.125c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062L6.751 15l-4.594-4.594c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062l2.125-2.125c.281-.281.672-.438 1.062-.438s.781.156 1.062.438L11 10.751l4.594-4.594c.281-.281.672-.438 1.062-.438s.781.156 1.062.438l2.125 2.125c.281.281.438.672.438 1.062s-.156.781-.438 1.062L15.249 15l4.594 4.594c.281.281.438.672.438 1.062z">
-                        </path>
-                    </svg></button>
-            </div>
-        </section>
-        <footer id="nav-footer" class="nav-footer">
-            <div class="center"><a href="/en-US/" class="nav-footer-logo">MDN Web Docs</a>
-                <div class="footer-group footer-group-mdn">
-                    <h2 class="footer-title">MDN</h2>
-                    <ul class="footer-list">
-                        <li><a href="/en-US/docs/Web">Web Technologies</a></li>
-                        <li><a href="/en-US/docs/Learn">Learn Web Development</a></li>
-                        <li><a href="/en-US/docs/MDN/About">About MDN</a></li>
-                        <li><a href="/en-US/docs/MDN/Feedback">Feedback</a></li>
-                        <li class="footer-social"><a href="https://twitter.com/mozdevnet"><svg class="icon icon-twitter"
-                                    xmlns="http://www.w3.org/2000/svg" width="26" height="28" aria-label="Twitter"
-                                    role="img" focusable="false">
-                                    <path
-                                        d="M25.312 6.375a10.85 10.85 0 0 1-2.531 2.609c.016.219.016.438.016.656 0 6.672-5.078 14.359-14.359 14.359-2.859 0-5.516-.828-7.75-2.266.406.047.797.063 1.219.063 2.359 0 4.531-.797 6.266-2.156a5.056 5.056 0 0 1-4.719-3.5c.313.047.625.078.953.078.453 0 .906-.063 1.328-.172a5.048 5.048 0 0 1-4.047-4.953v-.063a5.093 5.093 0 0 0 2.281.641 5.044 5.044 0 0 1-2.25-4.203c0-.938.25-1.797.688-2.547a14.344 14.344 0 0 0 10.406 5.281 5.708 5.708 0 0 1-.125-1.156 5.045 5.045 0 0 1 5.047-5.047 5.03 5.03 0 0 1 3.687 1.594 9.943 9.943 0 0 0 3.203-1.219 5.032 5.032 0 0 1-2.219 2.781c1.016-.109 2-.391 2.906-.781z">
-                                    </path>
-                                </svg></a></li>
-                        <li class="footer-social"><a href="https://github.com/mdn/"><svg class="icon icon-github"
-                                    xmlns="http://www.w3.org/2000/svg" width="24" height="28" aria-label="GitHub"
-                                    role="img" focusable="false">
-                                    <path
-                                        d="M12 2c6.625 0 12 5.375 12 12 0 5.297-3.437 9.797-8.203 11.391-.609.109-.828-.266-.828-.578 0-.391.016-1.687.016-3.297 0-1.125-.375-1.844-.812-2.219 2.672-.297 5.484-1.313 5.484-5.922 0-1.313-.469-2.375-1.234-3.219.125-.313.531-1.531-.125-3.187-1-.313-3.297 1.234-3.297 1.234a11.28 11.28 0 0 0-6 0S6.704 6.656 5.704 6.969c-.656 1.656-.25 2.875-.125 3.187-.766.844-1.234 1.906-1.234 3.219 0 4.594 2.797 5.625 5.469 5.922-.344.313-.656.844-.766 1.609-.688.313-2.438.844-3.484-1-.656-1.141-1.844-1.234-1.844-1.234-1.172-.016-.078.734-.078.734.781.359 1.328 1.75 1.328 1.75.703 2.141 4.047 1.422 4.047 1.422 0 1 .016 1.937.016 2.234 0 .313-.219.688-.828.578C3.439 23.796.002 19.296.002 13.999c0-6.625 5.375-12 12-12zM4.547 19.234c.031-.063-.016-.141-.109-.187-.094-.031-.172-.016-.203.031-.031.063.016.141.109.187.078.047.172.031.203-.031zm.484.532c.063-.047.047-.156-.031-.25-.078-.078-.187-.109-.25-.047-.063.047-.047.156.031.25.078.078.187.109.25.047zm.469.703c.078-.063.078-.187 0-.297-.063-.109-.187-.156-.266-.094-.078.047-.078.172 0 .281s.203.156.266.109zm.656.656c.063-.063.031-.203-.063-.297-.109-.109-.25-.125-.313-.047-.078.063-.047.203.063.297.109.109.25.125.313.047zm.891.391c.031-.094-.063-.203-.203-.25-.125-.031-.266.016-.297.109s.063.203.203.234c.125.047.266 0 .297-.094zm.984.078c0-.109-.125-.187-.266-.172-.141 0-.25.078-.25.172 0 .109.109.187.266.172.141 0 .25-.078.25-.172zm.906-.156c-.016-.094-.141-.156-.281-.141-.141.031-.234.125-.219.234.016.094.141.156.281.125s.234-.125.219-.219z">
-                                    </path>
-                                </svg></a></li>
-                    </ul>
-                </div><a href="https://mozilla.org" class="nav-footer-mozilla">Mozilla</a>
-                <div class="footer-group footer-group-mozilla">
-                    <h2 class="footer-title">Mozilla</h2>
-                    <ul class="footer-list">
-                        <li><a href="https://www.mozilla.org/about/">About</a></li>
-                        <li><a href="https://www.mozilla.org/contact/">Contact Us</a></li>
-                        <li><a
-                                href="https://www.mozilla.org/firefox/?utm_source=developer.mozilla.org&amp;utm_campaign=footer&amp;utm_medium=referral">Firefox</a>
-                        </li>
-                        <li class="footer-social"><a href="https://twitter.com/mozilla"><svg class="icon icon-twitter"
-                                    xmlns="http://www.w3.org/2000/svg" width="26" height="28" aria-label="Twitter"
-                                    role="img" focusable="false">
-                                    <path
-                                        d="M25.312 6.375a10.85 10.85 0 0 1-2.531 2.609c.016.219.016.438.016.656 0 6.672-5.078 14.359-14.359 14.359-2.859 0-5.516-.828-7.75-2.266.406.047.797.063 1.219.063 2.359 0 4.531-.797 6.266-2.156a5.056 5.056 0 0 1-4.719-3.5c.313.047.625.078.953.078.453 0 .906-.063 1.328-.172a5.048 5.048 0 0 1-4.047-4.953v-.063a5.093 5.093 0 0 0 2.281.641 5.044 5.044 0 0 1-2.25-4.203c0-.938.25-1.797.688-2.547a14.344 14.344 0 0 0 10.406 5.281 5.708 5.708 0 0 1-.125-1.156 5.045 5.045 0 0 1 5.047-5.047 5.03 5.03 0 0 1 3.687 1.594 9.943 9.943 0 0 0 3.203-1.219 5.032 5.032 0 0 1-2.219 2.781c1.016-.109 2-.391 2.906-.781z">
-                                    </path>
-                                </svg></a></li>
-                        <li class="footer-social"><a href="https://www.instagram.com/mozillagram/"><svg
-                                    class="icon icon-instagram" xmlns="http://www.w3.org/2000/svg" width="24"
-                                    height="28" aria-label="Instagram" role="img" focusable="false">
-                                    <path
-                                        d="M16 14c0-2.203-1.797-4-4-4s-4 1.797-4 4 1.797 4 4 4 4-1.797 4-4zm2.156 0c0 3.406-2.75 6.156-6.156 6.156S5.844 17.406 5.844 14 8.594 7.844 12 7.844s6.156 2.75 6.156 6.156zm1.688-6.406c0 .797-.641 1.437-1.437 1.437S16.97 8.39 16.97 7.594s.641-1.437 1.437-1.437 1.437.641 1.437 1.437zM12 4.156c-1.75 0-5.5-.141-7.078.484-.547.219-.953.484-1.375.906s-.688.828-.906 1.375c-.625 1.578-.484 5.328-.484 7.078s-.141 5.5.484 7.078c.219.547.484.953.906 1.375s.828.688 1.375.906c1.578.625 5.328.484 7.078.484s5.5.141 7.078-.484c.547-.219.953-.484 1.375-.906s.688-.828.906-1.375c.625-1.578.484-5.328.484-7.078s.141-5.5-.484-7.078c-.219-.547-.484-.953-.906-1.375s-.828-.688-1.375-.906C17.5 4.015 13.75 4.156 12 4.156zM24 14c0 1.656.016 3.297-.078 4.953-.094 1.922-.531 3.625-1.937 5.031s-3.109 1.844-5.031 1.937c-1.656.094-3.297.078-4.953.078s-3.297.016-4.953-.078c-1.922-.094-3.625-.531-5.031-1.937S.173 20.875.08 18.953C-.014 17.297.002 15.656.002 14s-.016-3.297.078-4.953c.094-1.922.531-3.625 1.937-5.031s3.109-1.844 5.031-1.937c1.656-.094 3.297-.078 4.953-.078s3.297-.016 4.953.078c1.922.094 3.625.531 5.031 1.937s1.844 3.109 1.937 5.031C24.016 10.703 24 12.344 24 14z">
-                                    </path>
-                                </svg></a></li>
-                    </ul>
-                </div>
-                <ul class="footer-tos">
-                    <li><a href="https://www.mozilla.org/about/legal/terms/mozilla">Terms</a></li>
-                    <li><a href="https://www.mozilla.org/privacy/websites/">Privacy</a></li>
-                    <li><a href="https://www.mozilla.org/privacy/websites/#cookies">Cookies</a></li>
+            </article>
+            <div class="metadata">
+              <section class="document-meta">
+                <header class="visually-hidden">
+                  <h4>Metadata</h4>
+                </header>
+                <ul>
+                  <li class="last-modified">
+                    <b>Last modified:</b>
+                    <time datetime="2019-12-25T10:51:18.956137"
+                      >Dec 25, 2019</time
+                    >,
+                    <!-- -->
+                    <!-- <a
+                      href="https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach$history"
+                      rel="nofollow"
+                      >by MDN contributors</a
+                    > -->
+                  </li>
                 </ul>
-                <div id="license" class="contentinfo">
-                    <p>© 2005-
-                        <!-- -->2020
-                        <!-- --> Mozilla and individual contributors.</p>
-                    <p>Content is available under
-                        <!-- --> <a href="/docs/MDN/About#Copyrights_and_licenses">these licenses</a>.</p>
-                </div>
+              </section>
             </div>
-        </footer>
-        <div class="notification">
-            <div>Would you answer 4 questions for us? <a target="_blank" rel="noopener noreferrer"
-                    href="https://www.surveygizmo.com/s3/2980494/do-or-do-not?t=1578305997492&amp;p=%2Fen-US%2Fdocs%2FWeb%2FJavaScript%2FReference%2FGlobal_Objects%2FArray%2FforEach">Open
-                    the survey in a new tab</a> and fill it out when you are done on the site. Thanks!</div><button
-                class="dismiss-button" aria-label="Dismiss"><svg class="dismiss-icon" xmlns="http://www.w3.org/2000/svg"
-                    role="presentation" viewBox="0 0 24 28">
-                    <path
-                        d="M20.281 20.656c0 .391-.156.781-.438 1.062l-2.125 2.125c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438L11 19.249l-4.594 4.594c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438l-2.125-2.125c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062L6.751 15l-4.594-4.594c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062l2.125-2.125c.281-.281.672-.438 1.062-.438s.781.156 1.062.438L11 10.751l4.594-4.594c.281-.281.672-.438 1.062-.438s.781.156 1.062.438l2.125 2.125c.281.281.438.672.438 1.062s-.156.781-.438 1.062L15.249 15l4.594 4.594c.281.281.438.672.438 1.062z">
-                    </path>
-                </svg></button>
+          </div>
+          <div class="sidebar">
+            <div class="quick-links">
+              <div class="quick-links-head sidebar-heading">Related Topics</div>
+              <div>
+                <ol>
+                  <li>
+                    <strong><a href="/">Standard built-in objects</a></strong>
+                  </li>
+                  <li>
+                    <strong
+                      ><a href="/"><code>Array</code></a></strong
+                    >
+                  </li>
+                  <li data-default-state="open">
+                    <a href="#"><strong>Properties</strong></a>
+                    <ol>
+                      <li>
+                        <a
+                          href="/"
+                          title="The length property of an object which is an instance of type Array sets or returns the number of elements in that array. The value is an unsigned, 32-bit integer that is always numerically greater than the highest index in the array."
+                          ><code>Array.length</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The @@unscopable symbol property contains property names that were not included in the ECMAScript standard prior to the ES2015 version. These properties are excluded from with statement bindings."
+                          ><code>Array.prototype[@@unscopables]</code></a
+                        >
+                      </li>
+                    </ol>
+                  </li>
+                  <li data-default-state="open">
+                    <a href="#"><strong>Methods</strong></a>
+                    <ol>
+                      <li>
+                        <a
+                          href="/"
+                          title="The Array.from() method creates a new, shallow-copied Array instance from an array-like or iterable object."
+                          ><code>Array.from()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The Array.isArray()&nbsp;method&nbsp;determines whether the passed value is an Array."
+                          ><code>Array.isArray()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title='The Array.observe() method was used for asynchronously observing changes to Arrays, similar to Object.observe() for objects. It provided a stream of changes in order of occurrence. It&apos;s equivalent to Object.observe() invoked with the accept type list ["add", "update", "delete", "splice"]. However, this API has been deprecated and removed from Browsers. You can use the more general Proxy object instead.'
+                            ><code>Array.observe()</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The Array.of() method creates a new Array instance from a variable number of arguments, regardless of number or type of the arguments."
+                          ><code>Array.of()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The concat() method is used to merge two or more arrays. This method does not change the existing arrays, but instead returns a new array."
+                          ><code>Array.prototype.concat()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The copyWithin() method shallow copies part of an array to another location in the same array and returns it&nbsp;without modifying its length."
+                          ><code>Array.prototype.copyWithin()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The entries() method returns a new Array Iterator object that contains the key/value pairs for each index in the array."
+                          ><code>Array.prototype.entries()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The every() method tests whether all elements in the array pass the test implemented by the provided function. It returns a Boolean value."
+                          ><code>Array.prototype.every()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The fill() method changes all elements in an array to a static value, from a start index&nbsp;(default 0) to an end index&nbsp;(default array.length). It returns the modified array."
+                          ><code>Array.prototype.fill()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The filter() method creates a new array with all elements that pass the test implemented by the provided function."
+                          ><code>Array.prototype.filter()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The find() method returns the value of the first element in the provided array that satisfies the provided testing function."
+                          ><code>Array.prototype.find()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The findIndex() method returns the index of the first element in the array that satisfies the provided testing function. Otherwise, it returns -1, indicating that no element passed the test."
+                          ><code>Array.prototype.findIndex()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The flat() method creates a new array with all sub-array elements concatenated into it recursively up to the specified depth."
+                          ><code>Array.prototype.flat()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The flatMap() method first maps each element using a mapping function, then flattens the result into a new array. It is identical to a map() followed by a flat() of depth 1, but flatMap() is often quite useful, as merging both into one method is slightly more efficient."
+                          ><code>Array.prototype.flatMap()</code></a
+                        >
+                      </li>
+                      <li>
+                        <em><code>Array.prototype.forEach()</code></em>
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The includes() method determines whether an array includes a certain value among its entries, returning true or false as appropriate."
+                          ><code>Array.prototype.includes()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The indexOf() method returns the first index at which a given element can be found in the array, or -1 if it is not present."
+                          ><code>Array.prototype.indexOf()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The join() method creates and returns a new string by concatenating all of the elements in an array (or an array-like object), separated by commas or a specified separator string. If the array has only one item, then that item will be returned without using the separator."
+                          ><code>Array.prototype.join()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The keys() method returns a new Array Iterator object that contains the keys for each index in the array."
+                          ><code>Array.prototype.keys()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The lastIndexOf() method returns the last index at which a given element can be found in the array, or -1 if it is not present. The array is searched backwards, starting at fromIndex."
+                          ><code>Array.prototype.lastIndexOf()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The map() method creates a new array with the results of calling a provided function on every element in the calling&nbsp;array."
+                          ><code>Array.prototype.map()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The pop() method removes the last element from an array and returns that element. This method changes the length of the array."
+                          ><code>Array.prototype.pop()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The push() method adds one or more elements to the end of an array and returns the new length of the array."
+                          ><code>Array.prototype.push()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The reduce() method executes a reducer function (that you provide) on each element of the array, resulting in a single output value."
+                          ><code>Array.prototype.reduce()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The reduceRight() method applies a function against an accumulator and each value of the array (from right-to-left) to reduce it to a single value."
+                          ><code>Array.prototype.reduceRight()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The reverse() method reverses an array in place. The first array element becomes the last, and the last array element becomes the first."
+                          ><code>Array.prototype.reverse()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The shift() method removes the first element from an array and returns that removed element. This method changes the length of the array."
+                          ><code>Array.prototype.shift()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The slice() method returns a shallow copy of a portion of an array into a new array object selected from begin to end (end not included) where begin and end represent the index of items in that array. The original array will not be modified."
+                          ><code>Array.prototype.slice()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The some() method tests whether at least one&nbsp;element in the array passes the test implemented by the provided function. It returns a Boolean value."
+                          ><code>Array.prototype.some()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The sort() method sorts the elements of an array in place and returns the sorted array. The default sort order is ascending, built upon converting the elements into strings, then comparing their sequences of UTF-16 code units values."
+                          ><code>Array.prototype.sort()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The splice() method changes the contents of an array by removing or replacing existing elements and/or adding new elements in place."
+                          ><code>Array.prototype.splice()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The toLocaleString() method returns a string representing the elements of the array. The elements are converted to Strings using their toLocaleString methods and these Strings are separated by a locale-specific String (such as a comma “,”)."
+                          ><code>Array.prototype.toLocaleString()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The toSource() method returns a string representing the source code of the array."
+                          ><code>Array.prototype.toSource()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The toString() method returns a string representing the specified array and its elements."
+                          ><code>Array.prototype.toString()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The unshift() method adds one or more elements to the beginning of an array and returns the new length of the array."
+                          ><code>Array.prototype.unshift()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The values() method returns a new Array Iterator object that contains the values for each index in the array."
+                          ><code>Array.prototype.values()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The initial value of the @@iterator property is the same function object as the initial value of the values() property."
+                          ><code>Array.prototype[@@iterator]()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title="The Array.unobserve() method was used to remove observers set by Array.observe(), but has been deprecated and removed from Browsers. You can use the more general Proxy object instead."
+                            ><code>Array.unobserve()</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The Array[@@species] accessor property returns the Array constructor."
+                          ><code>get Array[@@species]</code></a
+                        >
+                      </li>
+                    </ol>
+                  </li>
+                  <li><strong>Inheritance:</strong></li>
+                  <li>
+                    <strong
+                      ><a href="/"><code>Function</code></a></strong
+                    >
+                  </li>
+                  <li>
+                    <a href="#"><strong>Properties</strong></a>
+                    <ol>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This deprecated API should no longer be used, but will probably still work."
+                            ><i class="icon-thumbs-down-alt"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The function.arguments property refers to an an array-like object corresponding to the arguments passed to a function. Use the simple variable arguments instead. This property is forbidden in strict mode."
+                          ><code>Function.arguments</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title="Implemented in JavaScript 1.2. Deprecated in JavaScript 1.4."
+                            ><code>Function.arity</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The function.caller property returns the function that invoked the specified function. This property is forbidden in strict mode."
+                          ><code>Function.caller</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The function.displayName property returns the display name of the function."
+                          ><code>Function.displayName</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The length property indicates&nbsp;the number of parameters expected by the function."
+                          ><code>Function.length</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="A Function object's read-only name property indicates the function's name as specified when it was created, or it may be rather&nbsp;anonymous&nbsp;or ''(an empty string)&nbsp;for functions created anonymously."
+                          ><code>Function.name</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The Function.prototype property represents the Function prototype object."
+                          ><code>Function.prototype</code></a
+                        >
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <a href="#"><strong>Methods</strong></a>
+                    <ol>
+                      <li>
+                        <a
+                          href="/"
+                          title="The apply() method calls a function with a given this value, and arguments provided as an array (or an array-like object)."
+                          ><code>Function.prototype.apply()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The bind() method creates a new function that, when called, has its this keyword set to the provided value, with a given sequence of arguments preceding any provided when the new function is called."
+                          ><code>Function.prototype.bind()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The call() method calls a function with a given this value and arguments provided individually."
+                          ><code>Function.prototype.call()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title="The non-standard isGenerator() method used to determine whether or not a function is a generator. It has been removed from Firefox starting with version 58."
+                            ><code>Function.prototype.isGenerator()</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The toSource() method returns a string representing the source code of the object."
+                          ><code>Function.prototype.toSource()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The toString() method returns a string representing the source code of the function."
+                          ><code>Function.prototype.toString()</code></a
+                        >
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <strong
+                      ><a href="/"><code>Object</code></a></strong
+                    >
+                  </li>
+                  <li>
+                    <a href="#"><strong>Properties</strong></a>
+                    <ol>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title="The __count__ property used to store the count of enumerable properties on the object, but it has been removed."
+                            ><code>Object.prototype.__count__</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title="The __noSuchMethod__ property used to reference a function to be executed when a non-existent method is called on an object, but this function is no longer available."
+                            ><code>Object.prototype.__noSuchMethod__</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title="The __parent__ property used to point to an object's context, but it has been removed."
+                            ><code>Object.prototype.__parent__</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This deprecated API should no longer be used, but will probably still work."
+                            ><i class="icon-thumbs-down-alt"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The __proto__ property of Object.prototype is an accessor property (a getter function and a setter function) that exposes the internal [[Prototype]] (either an object or null) of the object through which it is accessed."
+                          ><code>Object.prototype.__proto__</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The constructor property returns a reference to the Object constructor function that created the instance object. Note that the value of this property is a reference to the function itself, not a string containing the function's name."
+                          ><code>Object.prototype.constructor</code></a
+                        >
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    <a href="#"><strong>Methods</strong></a>
+                    <ol>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This deprecated API should no longer be used, but will probably still work."
+                            ><i class="icon-thumbs-down-alt"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The __defineGetter__ method binds an object's property to a function to be called when that property is looked up."
+                          ><code>Object.prototype.__defineGetter__()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This deprecated API should no longer be used, but will probably still work."
+                            ><i class="icon-thumbs-down-alt"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The __defineSetter__ method binds an object's property to a function to be called when an attempt is made to set that property."
+                          ><code>Object.prototype.__defineSetter__()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This deprecated API should no longer be used, but will probably still work."
+                            ><i class="icon-thumbs-down-alt"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The __lookupGetter__ method returns the function bound as a getter to the specified property."
+                          ><code>Object.prototype.__lookupGetter__()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This deprecated API should no longer be used, but will probably still work."
+                            ><i class="icon-thumbs-down-alt"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The __lookupSetter__ method returns the function bound as a setter to the specified property."
+                          ><code>Object.prototype.__lookupSetter__()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The hasOwnProperty() method returns a boolean indicating whether the object has the specified property as its own property (as opposed to inheriting it)."
+                          ><code>Object.prototype.hasOwnProperty()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The isPrototypeOf() method checks if an object exists in another object's prototype chain."
+                          ><code>Object.prototype.isPrototypeOf()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The propertyIsEnumerable() method returns a Boolean indicating whether the specified property is enumerable and is the object's own property."
+                          ><code
+                            >Object.prototype.propertyIsEnumerable()</code
+                          ></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The toLocaleString() method returns a string representing the object. This method is meant to be overridden by derived objects for locale-specific purposes."
+                          ><code>Object.prototype.toLocaleString()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This API has not been standardized."
+                            ><i class="icon-warning-sign"> </i></span></span
+                        ><a
+                          href="/"
+                          title="The toSource() method returns a string representing the source code of the object."
+                          ><code>Object.prototype.toSource()</code></a
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The toString() method returns a string representing the object."
+                          ><code>Object.prototype.toString()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This deprecated API should no longer be used, but will probably still work."
+                            ><i class="icon-thumbs-down-alt"> </i></span></span
+                        ><span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title="The unwatch() method removes a watchpoint set with the watch() method."
+                            ><code>Object.prototype.unwatch()</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The valueOf() method returns the primitive value of the specified object."
+                          ><code>Object.prototype.valueOf()</code></a
+                        >
+                      </li>
+                      <li>
+                        <span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This deprecated API should no longer be used, but will probably still work."
+                            ><i class="icon-thumbs-down-alt"> </i></span></span
+                        ><span class="sidebar-icon"
+                          ><span
+                            class="icon-only-inline"
+                            title="This is an obsolete API and is no longer guaranteed to work."
+                            ><i class="icon-trash"> </i></span></span
+                        ><s class="obsoleteElement"
+                          ><a
+                            href="/"
+                            title="The watch() method watches for a property to be assigned a value and runs a function when that occurs."
+                            ><code>Object.prototype.watch()</code></a
+                          ></s
+                        >
+                      </li>
+                      <li>
+                        <a
+                          href="/"
+                          title="The Object.setPrototypeOf() method sets the prototype (i.e., the internal [[Prototype]] property) of a specified object to another object or null."
+                          ><code>Object.setPrototypeOf()</code></a
+                        >
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </div>
+            </div>
+          </div>
         </div>
+      </main>
+      <section class="newsletter-container">
+        <div id="newsletter-form-container" class="newsletter">
+          <form class="newsletter-form nodisable" name="newsletter-form">
+            <section class="newsletter-head">
+              <h2 class="newsletter-teaser">
+                Learn the best of web development
+              </h2>
+              <p class="newsletter-description">
+                Get the latest and greatest from MDN delivered straight to your
+                inbox.
+              </p>
+              <p class="hidden" aria-hidden="true">
+                The newsletter is offered in English only at the moment.
+              </p>
+            </section>
+            <fieldset class="newsletter-fields">
+              <input type="hidden" name="fmt" value="H" /><input
+                type="hidden"
+                name="newsletters"
+                value="app-dev"
+              />
+              <div class="form-group newsletter-group-email">
+                <label for="newsletter-email-input" class="form-label offscreen"
+                  >E-mail</label
+                ><input
+                  type="email"
+                  id="newsletter-email-input"
+                  name="email"
+                  class="form-input newsletter-input-email"
+                  placeholder="you@example.com"
+                  required=""
+                />
+              </div>
+
+              <div id="newsletter-privacy" class="hidden" aria-hidden="true">
+                <input
+                  type="checkbox"
+                  id="newsletter-privacy-input"
+                  name="privacy"
+                  required=""
+                /><label for="newsletter-privacy-input"
+                  >I’m okay with Mozilla handling my info as explained in this
+                  <a href="https://www.mozilla.org/privacy/">Privacy Policy</a
+                  >.</label
+                >
+              </div>
+              <div class="newsletter-group-submit">
+                <button
+                  id="newsletter-submit"
+                  type="submit"
+                  class="button neutral newsletter-submit"
+                >
+                  Sign up now
+                </button>
+              </div>
+            </fieldset>
+          </form>
+          <button
+            type="button"
+            class="only-icon newsletter-hide"
+            aria-controls="newsletter-form-container"
+          >
+            <span>Hide Newsletter Sign-up</span
+            ><svg
+              class="icon icon-close"
+              xmlns="http://www.w3.org/2000/svg"
+              role="presentation"
+              viewBox="0 0 24 28"
+            >
+              <path
+                d="M20.281 20.656c0 .391-.156.781-.438 1.062l-2.125 2.125c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438L11 19.249l-4.594 4.594c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438l-2.125-2.125c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062L6.751 15l-4.594-4.594c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062l2.125-2.125c.281-.281.672-.438 1.062-.438s.781.156 1.062.438L11 10.751l4.594-4.594c.281-.281.672-.438 1.062-.438s.781.156 1.062.438l2.125 2.125c.281.281.438.672.438 1.062s-.156.781-.438 1.062L15.249 15l4.594 4.594c.281.281.438.672.438 1.062z"
+              ></path>
+            </svg>
+          </button>
+        </div>
+      </section>
+      <footer id="nav-footer" class="nav-footer">
+        <div class="center">
+          <a href="/" class="nav-footer-logo">MDN Web Docs</a>
+          <div class="footer-group footer-group-mdn">
+            <h2 class="footer-title">MDN</h2>
+            <ul class="footer-list">
+              <li><a href="/">Web Technologies</a></li>
+              <li><a href="/">Learn Web Development</a></li>
+              <li><a href="/">About MDN</a></li>
+              <li><a href="/">Feedback</a></li>
+              <li class="footer-social">
+                <a href="https://twitter.com/mozdevnet"
+                  ><svg
+                    class="icon icon-twitter"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="26"
+                    height="28"
+                    aria-label="Twitter"
+                    role="img"
+                    focusable="false"
+                  >
+                    <path
+                      d="M25.312 6.375a10.85 10.85 0 0 1-2.531 2.609c.016.219.016.438.016.656 0 6.672-5.078 14.359-14.359 14.359-2.859 0-5.516-.828-7.75-2.266.406.047.797.063 1.219.063 2.359 0 4.531-.797 6.266-2.156a5.056 5.056 0 0 1-4.719-3.5c.313.047.625.078.953.078.453 0 .906-.063 1.328-.172a5.048 5.048 0 0 1-4.047-4.953v-.063a5.093 5.093 0 0 0 2.281.641 5.044 5.044 0 0 1-2.25-4.203c0-.938.25-1.797.688-2.547a14.344 14.344 0 0 0 10.406 5.281 5.708 5.708 0 0 1-.125-1.156 5.045 5.045 0 0 1 5.047-5.047 5.03 5.03 0 0 1 3.687 1.594 9.943 9.943 0 0 0 3.203-1.219 5.032 5.032 0 0 1-2.219 2.781c1.016-.109 2-.391 2.906-.781z"
+                    ></path></svg
+                ></a>
+              </li>
+              <li class="footer-social">
+                <a href="https://github.com/mdn/"
+                  ><svg
+                    class="icon icon-github"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="28"
+                    aria-label="GitHub"
+                    role="img"
+                    focusable="false"
+                  >
+                    <path
+                      d="M12 2c6.625 0 12 5.375 12 12 0 5.297-3.437 9.797-8.203 11.391-.609.109-.828-.266-.828-.578 0-.391.016-1.687.016-3.297 0-1.125-.375-1.844-.812-2.219 2.672-.297 5.484-1.313 5.484-5.922 0-1.313-.469-2.375-1.234-3.219.125-.313.531-1.531-.125-3.187-1-.313-3.297 1.234-3.297 1.234a11.28 11.28 0 0 0-6 0S6.704 6.656 5.704 6.969c-.656 1.656-.25 2.875-.125 3.187-.766.844-1.234 1.906-1.234 3.219 0 4.594 2.797 5.625 5.469 5.922-.344.313-.656.844-.766 1.609-.688.313-2.438.844-3.484-1-.656-1.141-1.844-1.234-1.844-1.234-1.172-.016-.078.734-.078.734.781.359 1.328 1.75 1.328 1.75.703 2.141 4.047 1.422 4.047 1.422 0 1 .016 1.937.016 2.234 0 .313-.219.688-.828.578C3.439 23.796.002 19.296.002 13.999c0-6.625 5.375-12 12-12zM4.547 19.234c.031-.063-.016-.141-.109-.187-.094-.031-.172-.016-.203.031-.031.063.016.141.109.187.078.047.172.031.203-.031zm.484.532c.063-.047.047-.156-.031-.25-.078-.078-.187-.109-.25-.047-.063.047-.047.156.031.25.078.078.187.109.25.047zm.469.703c.078-.063.078-.187 0-.297-.063-.109-.187-.156-.266-.094-.078.047-.078.172 0 .281s.203.156.266.109zm.656.656c.063-.063.031-.203-.063-.297-.109-.109-.25-.125-.313-.047-.078.063-.047.203.063.297.109.109.25.125.313.047zm.891.391c.031-.094-.063-.203-.203-.25-.125-.031-.266.016-.297.109s.063.203.203.234c.125.047.266 0 .297-.094zm.984.078c0-.109-.125-.187-.266-.172-.141 0-.25.078-.25.172 0 .109.109.187.266.172.141 0 .25-.078.25-.172zm.906-.156c-.016-.094-.141-.156-.281-.141-.141.031-.234.125-.219.234.016.094.141.156.281.125s.234-.125.219-.219z"
+                    ></path></svg
+                ></a>
+              </li>
+            </ul>
+          </div>
+          <a href="https://mozilla.org" class="nav-footer-mozilla">Mozilla</a>
+          <div class="footer-group footer-group-mozilla">
+            <h2 class="footer-title">Mozilla</h2>
+            <ul class="footer-list">
+              <li><a href="https://www.mozilla.org/about/">About</a></li>
+              <li><a href="https://www.mozilla.org/contact/">Contact Us</a></li>
+              <li>
+                <a
+                  href="https://www.mozilla.org/firefox/?utm_source=developer.mozilla.org&amp;utm_campaign=footer&amp;utm_medium=referral"
+                  >Firefox</a
+                >
+              </li>
+              <li class="footer-social">
+                <a href="https://twitter.com/mozilla"
+                  ><svg
+                    class="icon icon-twitter"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="26"
+                    height="28"
+                    aria-label="Twitter"
+                    role="img"
+                    focusable="false"
+                  >
+                    <path
+                      d="M25.312 6.375a10.85 10.85 0 0 1-2.531 2.609c.016.219.016.438.016.656 0 6.672-5.078 14.359-14.359 14.359-2.859 0-5.516-.828-7.75-2.266.406.047.797.063 1.219.063 2.359 0 4.531-.797 6.266-2.156a5.056 5.056 0 0 1-4.719-3.5c.313.047.625.078.953.078.453 0 .906-.063 1.328-.172a5.048 5.048 0 0 1-4.047-4.953v-.063a5.093 5.093 0 0 0 2.281.641 5.044 5.044 0 0 1-2.25-4.203c0-.938.25-1.797.688-2.547a14.344 14.344 0 0 0 10.406 5.281 5.708 5.708 0 0 1-.125-1.156 5.045 5.045 0 0 1 5.047-5.047 5.03 5.03 0 0 1 3.687 1.594 9.943 9.943 0 0 0 3.203-1.219 5.032 5.032 0 0 1-2.219 2.781c1.016-.109 2-.391 2.906-.781z"
+                    ></path></svg
+                ></a>
+              </li>
+              <li class="footer-social">
+                <a href="https://www.instagram.com/mozillagram/"
+                  ><svg
+                    class="icon icon-instagram"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="28"
+                    aria-label="Instagram"
+                    role="img"
+                    focusable="false"
+                  >
+                    <path
+                      d="M16 14c0-2.203-1.797-4-4-4s-4 1.797-4 4 1.797 4 4 4 4-1.797 4-4zm2.156 0c0 3.406-2.75 6.156-6.156 6.156S5.844 17.406 5.844 14 8.594 7.844 12 7.844s6.156 2.75 6.156 6.156zm1.688-6.406c0 .797-.641 1.437-1.437 1.437S16.97 8.39 16.97 7.594s.641-1.437 1.437-1.437 1.437.641 1.437 1.437zM12 4.156c-1.75 0-5.5-.141-7.078.484-.547.219-.953.484-1.375.906s-.688.828-.906 1.375c-.625 1.578-.484 5.328-.484 7.078s-.141 5.5.484 7.078c.219.547.484.953.906 1.375s.828.688 1.375.906c1.578.625 5.328.484 7.078.484s5.5.141 7.078-.484c.547-.219.953-.484 1.375-.906s.688-.828.906-1.375c.625-1.578.484-5.328.484-7.078s.141-5.5-.484-7.078c-.219-.547-.484-.953-.906-1.375s-.828-.688-1.375-.906C17.5 4.015 13.75 4.156 12 4.156zM24 14c0 1.656.016 3.297-.078 4.953-.094 1.922-.531 3.625-1.937 5.031s-3.109 1.844-5.031 1.937c-1.656.094-3.297.078-4.953.078s-3.297.016-4.953-.078c-1.922-.094-3.625-.531-5.031-1.937S.173 20.875.08 18.953C-.014 17.297.002 15.656.002 14s-.016-3.297.078-4.953c.094-1.922.531-3.625 1.937-5.031s3.109-1.844 5.031-1.937c1.656-.094 3.297-.078 4.953-.078s3.297-.016 4.953.078c1.922.094 3.625.531 5.031 1.937s1.844 3.109 1.937 5.031C24.016 10.703 24 12.344 24 14z"
+                    ></path></svg
+                ></a>
+              </li>
+            </ul>
+          </div>
+          <ul class="footer-tos">
+            <li>
+              <a href="https://www.mozilla.org/about/legal/terms/mozilla"
+                >Terms</a
+              >
+            </li>
+            <li>
+              <a href="https://www.mozilla.org/privacy/websites/">Privacy</a>
+            </li>
+            <li>
+              <a href="https://www.mozilla.org/privacy/websites/#cookies"
+                >Cookies</a
+              >
+            </li>
+          </ul>
+          <div id="license" class="contentinfo">
+            <p>
+              © 2005-
+              <!-- -->2020
+              <!-- -->
+              Mozilla and individual contributors.
+            </p>
+            <p>
+              Content is available under
+              <!-- -->
+              <a href="/">these licenses</a>.
+            </p>
+          </div>
+        </div>
+      </footer>
+      <div class="notification">
+        <div>
+          Would you answer 4 questions for us?
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.surveygizmo.com/s3/2980494/do-or-do-not?t=1578305997492&amp;p=%2Fen-US%2Fdocs%2FWeb%2FJavaScript%2FReference%2FGlobal_Objects%2FArray%2FforEach"
+            >Open the survey in a new tab</a
+          >
+          and fill it out when you are done on the site. Thanks!
+        </div>
+        <button class="dismiss-button" aria-label="Dismiss">
+          <svg
+            class="dismiss-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            role="presentation"
+            viewBox="0 0 24 28"
+          >
+            <path
+              d="M20.281 20.656c0 .391-.156.781-.438 1.062l-2.125 2.125c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438L11 19.249l-4.594 4.594c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438l-2.125-2.125c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062L6.751 15l-4.594-4.594c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062l2.125-2.125c.281-.281.672-.438 1.062-.438s.781.156 1.062.438L11 10.751l4.594-4.594c.281-.281.672-.438 1.062-.438s.781.156 1.062.438l2.125 2.125c.281.281.438.672.438 1.062s-.156.781-.438 1.062L15.249 15l4.594 4.594c.281.281.438.672.438 1.062z"
+            ></path>
+          </svg>
+        </button>
+      </div>
     </div>
 
     <div id="auth-modal" class="modal hidden">
-        <section class="auth-providers" tabindex="-1" role="dialog" aria-modal="true"
-            aria-labelledby="modal-main-heading">
-            <header>
-                <h2 id="modal-main-heading">Sign In</h2>
-            </header>
+      <section
+        class="auth-providers"
+        tabindex="-1"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-main-heading"
+      >
+        <header>
+          <h2 id="modal-main-heading">Sign In</h2>
+        </header>
 
-            <p>
-                Sign in to enjoy the benefits of an MDN account. If you haven’t already created an MDN profile, you will
-                be prompted to do so after signing in.
-            </p>
-            <div class="auth-button-container">
-                <a href="/users/github/login/" class="github-auth" data-first-focusable="true">
-                    Sign in with Github
-                </a>
-                <a href="/users/google/login/" class="google-auth">
-                    Sign in with Google
-                </a>
-            </div>
+        <p>
+          Sign in to enjoy the benefits of an MDN account. If you haven’t
+          already created an MDN profile, you will be prompted to do so after
+          signing in.
+        </p>
+        <div class="auth-button-container">
+          <a href="/" class="github-auth" data-first-focusable="true">
+            Sign in with Github
+          </a>
+          <a href="/" class="google-auth">
+            Sign in with Google
+          </a>
+        </div>
 
-            <button id="close-modal" class="close-modal" data-last-focusable="true">
-                <span>Close modal</span>
-            </button>
-        </section>
+        <button id="close-modal" class="close-modal" data-last-focusable="true">
+          <span>Close modal</span>
+        </button>
+      </section>
     </div>
-
-
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION
This fixes the below error when running `yarn dev`: 

```
Server running at http://localhost:1234
🚨  /Users/mindy/Desktop/mdn-minimalist/pages/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach: ENOENT: no such file or directory, open '/Users/mindy/Desktop/mdn-minimalist/pages/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach'
Error: ENOENT: no such file or directory, open '/Users/mindy/Desktop/mdn-minimalist/pages/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach'
``` 

I think Parcel has issue with not being able to find anything at the referenced URL. 