### PR TITLE
(fix) bug between icon buttons and links

### DIFF
--- a/sass/atoms/_icons.scss
+++ b/sass/atoms/_icons.scss
@@ -6,8 +6,6 @@
   background-repeat: no-repeat;
   background-size: 21px;
   margin-right: 5px;
-  width: 21px;
-  height: 21px;
   vertical-align: sub;
 }
 

--- a/sass/atoms/_links.scss
+++ b/sass/atoms/_links.scss
@@ -12,13 +12,18 @@ a {
     color: $text-color-inverted;
   }
 
-  &[rel="external"]::before {
+  &[rel="external"]::before,
+  &.mailto::before {
     @extend .icon-base;
+    width: 21px;
+    height: 21px;
+  }
+
+  &[rel="external"]::before {
     background-image: url("/dinocons/general/external.svg");
   }
 
   &.mailto::before {
-    @extend .icon-base;
     background-image: url("/dinocons/general/email.svg");
   }
 }


### PR DESCRIPTION
The width and height added to icon-base breaks icon buttons. Move
width and height to instances of links with icons.

fix #36