### PR TITLE
(fix) collision with icon buttons and links

### DIFF
--- a/sass/atoms/_icons.scss
+++ b/sass/atoms/_icons.scss
@@ -1,7 +1,6 @@
 .icon-base {
   display: inline-block;
   content: "";
-  background-color: transparent;
   background-position: 0 0;
   background-repeat: no-repeat;
   background-size: 21px;


### PR DESCRIPTION
No need for the `background-color: transparent;` rule on `.icon-base`

fix #38