### PR TITLE
(fix) do not attach style to button element

### DIFF
--- a/sass/atoms/_buttons.scss
+++ b/sass/atoms/_buttons.scss
@@ -1,4 +1,3 @@
-button,
 .button,
 a.button {
   @include button-state();


### PR DESCRIPTION
Do not attach base style rules to elements directly. This will more
often than not cause the need for a lot of overrides in code that uses
this base framework. In general prefer the use of classes.

fix #45