### PR TITLE
(enhancement) ghost button

### DIFF
--- a/sass/atoms/_buttons.scss
+++ b/sass/atoms/_buttons.scss
@@ -66,6 +66,14 @@ a.inactive {
   );
 }
 
+/* Runs off most base default browser styles
+   for button elements. */
+.ghost {
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
 .icon {
   svg {
     margin-right: 10px;


### PR DESCRIPTION
Add style for ghost buttons. This removes the basic default
browser styles for button elements such as:

- `background-color`
- `border`

and adds `cursor: pointer;`

fix #48