### PR TITLE
(fix) inactive button state

### DIFF
--- a/sass/atoms/_buttons.scss
+++ b/sass/atoms/_buttons.scss
@@ -64,6 +64,7 @@ a.inactive {
     $bg-hover-color: $neutral-500,
     $text-color: $neutral-300
   );
+  cursor: default;
 }
 
 /* Runs off most base default browser styles


### PR DESCRIPTION
Inactive buttons should have its cursor set to default.

fix #62