### PR TITLE
(breaking) new grid for reference pages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
-sass/mixins/_base-mixins.scss
-sass/mixins/_indicators.scss
+public

--- a/sass/grid/_reference.scss
+++ b/sass/grid/_reference.scss
@@ -3,11 +3,6 @@
     .page-header,
     .titlebar-container,
     .breadcrumb-locale-container,
-    main,
-    .document-toc-container,
-    .article,
-    .sidebar,
-    .newsletter-container,
     .page-footer {
       grid-column: 1/4;
     }
@@ -32,40 +27,33 @@
       }
     }
 
-    main {
-      display: grid;
-      gap: 20px;
+    .document-toc-container {
+      grid-column: 1/4;
       grid-row: 4/5;
 
-      .document-toc-container {
-        grid-row: 1/2;
-
-        @media #{$mq-small-desktop-and-up} {
-          grid-column: 1/2;
-        }
-      }
-
-      .article {
-        grid-row: 2/3;
-
-        @media #{$mq-small-desktop-and-up} {
-          grid-row: 1/3;
-          grid-column: 2/4;
-        }
-      }
-
-      .sidebar {
-        grid-row: 3/4;
-
-        @media #{$mq-small-desktop-and-up} {
-          grid-row: 2/3;
-          grid-column: 1/2;
-        }
+      @media #{$mq-small-desktop-and-up} {
+        grid-column: 1/2;
       }
     }
 
-    .newsletter-container {
+    .main-content {
+      grid-column: 1/4;
       grid-row: 5/6;
+
+      @media #{$mq-small-desktop-and-up} {
+        grid-column: 2/4;
+        grid-row: 4/6;
+      }
+    }
+
+    .sidebar {
+      grid-column: 1/4;
+      grid-row: 7/8;
+
+      @media #{$mq-small-desktop-and-up} {
+        grid-column: 1/2;
+        grid-row: 5/6;
+      }
     }
 
     .page-footer {


### PR DESCRIPTION
Update to reference page grid. This also removes the slot for the
footer newsletter

fix #76 fix #75