### PR TITLE
(fix) relative paths for fonts

### DIFF
--- a/sass/atoms/_typography.scss
+++ b/sass/atoms/_typography.scss
@@ -1,8 +1,8 @@
 @font-face {
   font-family: zillaslab;
   font-display: swap;
-  src: url("/typography/ZillaSlab-Bold.subset.woff2") format("woff2"),
-    url("/typography/ZillaSlab-Bold.subset.woff") format("woff");
+  src: url("../../typography/ZillaSlab-Bold.subset.woff2") format("woff2"),
+    url("../../typography/ZillaSlab-Bold.subset.woff") format("woff");
   font-weight: bold;
   font-style: normal;
 }
@@ -10,8 +10,8 @@
 @font-face {
   font-family: zillaslab;
   font-display: swap;
-  src: url("/typography/ZillaSlab-Regular.subset.woff2") format("woff2"),
-    url("/typography/ZillaSlab-Regular.subset.woff") format("woff");
+  src: url("../../typography/ZillaSlab-Regular.subset.woff2") format("woff2"),
+    url("../../typography/ZillaSlab-Regular.subset.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }


### PR DESCRIPTION
Reference font files using relative paths

fix #80