### PR TITLE
reference page grid for mobile incorrect

### DIFF
--- a/sass/grid/_reference.scss
+++ b/sass/grid/_reference.scss
@@ -48,7 +48,7 @@
 
     .sidebar {
       grid-column: 1/4;
-      grid-row: 7/8;
+      grid-row: 6/7;
 
       @media #{$mq-small-desktop-and-up} {
         grid-column: 1/2;
@@ -57,7 +57,7 @@
     }
 
     .page-footer {
-      grid-row: 6/7;
+      grid-row: 7/8;
     }
   }
 }


### PR DESCRIPTION
The reference page grid incorrectly places the sidebar below the footer on mobile.

fix #84