### PR TITLE
create shared variables file

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+sass/shared-variables.scss

--- a/sass/shared-variables.scss
+++ b/sass/shared-variables.scss
@@ -1,0 +1,12 @@
+@import "./vars/color-palette";
+
+:export {
+  primary100: $primary-100;
+  primary110: $primary-110;
+  primary200: $primary-200;
+  primary300: $primary-300;
+  primary400: $primary-400;
+  primary500: $primary-500;
+  primary510: $primary-510;
+  primary600: $primary-600;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,10 @@ const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
-  entry: "./sass/mdn-minimalist.scss",
+  entry: {
+    main: "./sass/mdn-minimalist.scss",
+    shared: "./sass/shared-variables.scss",
+  },
   output: {
     path: path.resolve(__dirname, "public", "css"),
   },


### PR DESCRIPTION
Add a shared variables file that enables sharing of specific variables between SASS and JS without impacting the minimalist CSS.

fix #64