### PR TITLE
code element in prism blocks

### DIFF
--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -1,10 +1,13 @@
-.article {
-  pre {
-    background-color: $neutral-550;
-    border-left: $code-example-border;
-    max-width: 100%;
-    overflow: auto;
-    padding: ($base-spacing - 6);
-    width: 100%;
+code {
+  background-color: $neutral-400;
+  box-decoration-break: clone;
+  font-family: $code-inline-font-family;
+  padding: 0 2px;
+  word-wrap: break-word;
+}
+
+.notranslate {
+  code {
+    background-color: transparent;
   }
 }

--- a/sass/atoms/_typography.scss
+++ b/sass/atoms/_typography.scss
@@ -77,13 +77,3 @@ a:visited {
     text-decoration: underline;
   }
 }
-
-/* mono space elements pre, code, kbd */
-code {
-  background-color: rgba(220, 220, 220, 0.5);
-  border-radius: 2px;
-  box-decoration-break: clone;
-  font-family: $code-inline-font-family;
-  padding: 0 2px;
-  word-wrap: break-word;
-}

--- a/sass/mdn-minimalist.scss
+++ b/sass/mdn-minimalist.scss
@@ -1,7 +1,7 @@
 @import "./lib/reset";
 
-@import "./vars/layout";
 @import "./vars/color-palette";
+@import "./vars/layout";
 @import "./vars/borders";
 @import "./vars/typography";
 


### PR DESCRIPTION
`code` elements inside syntax highlighted code examples should not have a background color set.

fix #182