### PR TITLE
add code examples line height variable

### DIFF
--- a/sass/vars/_typography.scss
+++ b/sass/vars/_typography.scss
@@ -8,6 +8,7 @@ $code-inline-font-family: consolas, "Liberation Mono", courier, monospace;
 
 $base-font-size: 18px;
 $document-line-height: 1.6;
+$code-example-line-height: 1.4;
 $heading-line-height: 1.2;
 
 /* Desktop and tablet typescale based on perfect fourth typescale with a base of 18px */


### PR DESCRIPTION
Add `$code-example-line-height: 1.4;`

fix #196