### PR TITLE
fix: use yarn not npm

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 12
           registry-url: "https://registry.npmjs.org"
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:


### PR DESCRIPTION
Instead of doing `npm ci` in release-please use `yarn install --frozen-lockfile`