### PR TITLE
fix: adjust first header cell max width

### DIFF
--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -87,6 +87,10 @@
     border-bottom: $standard-light-border;
   }
 
+  tr th:first-child {
+    max-width: 90px;
+  }
+
   tr th:first-child,
   tr td:first-child {
     border-left: 0;


### PR DESCRIPTION
Adjust the max width of the first header cell to avoid overflow on mobile