### PR TITLE
fix: new desktop typescale

### DIFF
--- a/sass/vars/_typography.scss
+++ b/sass/vars/_typography.scss
@@ -11,12 +11,12 @@ $document-line-height: 1.6;
 $code-example-line-height: 1.4;
 $heading-line-height: 1.2;
 
-/* Desktop and tablet typescale based on perfect fourth typescale with a base of 18px */
-$xxl-font-size: 4.209rem; /* 75.76px */
-$xl-font-size: 3.157rem; /* 56.83px */
-$large-font-size: 2.369rem; /* 42.63px */
-$medium-font-size: 1.777rem; /* 32px */
-$small-medium-font-size: 1.333rem; /* 24px */
+/* Desktop and tablet typescale based on major third typescale with a base of 18px */
+$xxl-font-size: 3.052rem; /* 54.93px */
+$xl-font-size: 2.441rem; /* 43.95px */
+$large-font-size: 1.953rem; /* 35.16px */
+$medium-font-size: 1.563rem; /* 28.13px */
+$small-medium-font-size: 1.25rem; /* 22.50px */
 
 /* Mobile typescale based on minor third typescale with a base of 18px */
 $xxl-font-size-mobile: 2.488rem;


### PR DESCRIPTION
Switch to a major third typescale aka 1.250 with a base of 18px

fix #229