### PR TITLE
fix: default padding for standard grid

### DIFF
--- a/sass/grid/_standard.scss
+++ b/sass/grid/_standard.scss
@@ -23,6 +23,7 @@
       display: grid;
       grid-row: 3/4;
       grid-template-columns: 100%;
+      padding: $base-spacing;
     }
 
     .page-footer {


### PR DESCRIPTION
Add default padding to `page-content-container` for standard page grid