### PR TITLE
table updates

### DIFF
--- a/sass/atoms/_links.scss
+++ b/sass/atoms/_links.scss
@@ -6,4 +6,17 @@ a {
   &:focus {
     text-decoration: underline;
   }
+
+  &.external {
+    &::before {
+      background: transparent url("~@mdn/dinocons/general/external.svg") 0 0
+        no-repeat;
+      background-size: 16px;
+      content: "";
+      display: inline-block;
+      height: 16px;
+      margin-right: $base-spacing / 8;
+      width: 16px;
+    }
+  }
 }

--- a/sass/atoms/_meta.scss
+++ b/sass/atoms/_meta.scss
@@ -1,6 +1,6 @@
 /* General Badges */
 .badge {
-  background-color: $neutral-550;
+  background-color: $neutral-575;
   border-radius: 6px;
   margin-right: $base-spacing / 4;
   padding: 0 $base-spacing / 4;
@@ -38,7 +38,7 @@
 .spec-standard,
 .spec-wd {
   &::before {
-    background-color: $neutral-550;
+    background-color: $neutral-575;
     border-left: 5px solid $neutral-100;
     border-radius: 6px;
     display: inline-block;

--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -1,18 +1,23 @@
+table {
+  th,
+  td {
+    border: 1px solid $neutral-500;
+    padding: $base-spacing / 2;
+    text-align: left;
+  }
+}
+
 /* 
  * Standard table styles. For an example see:
  * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Events
  */
+table,
 .standard-table,
 .properties {
   border-collapse: collapse;
 
   a {
     color: $neutral-100;
-  }
-
-  th,
-  td {
-    text-align: left;
   }
 
   code {

--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -1,4 +1,10 @@
 table {
+  font-size: $small-font-size;
+
+  @media #{$mq-tablet-and-up} {
+    font-size: $default-font-size;
+  }
+
   th,
   td {
     border: 1px solid $neutral-500;
@@ -69,6 +75,7 @@ table,
 
   th,
   td {
+    border: 0;
     border-left: $standard-light-border;
     padding: ($base-spacing / 2);
   }
@@ -76,24 +83,11 @@ table,
   th {
     background-color: $neutral-550;
     border-bottom: $standard-light-border;
-    max-width: 110px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    @media #{$mq-small-desktop-and-up} {
-      max-width: inherit;
-      overflow: inherit;
-      text-overflow: inherit;
-    }
   }
 
   td {
     background-color: $neutral-550;
     border-bottom: $standard-light-border;
-  }
-
-  tr th:first-child {
-    max-width: 90px;
   }
 
   tr th:first-child,

--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -8,7 +8,6 @@
 
   a {
     color: $neutral-100;
-    text-decoration: underline;
   }
 
   th,
@@ -17,6 +16,7 @@
   }
 
   code {
+    background-color: transparent;
     hyphens: auto;
   }
 }
@@ -83,7 +83,7 @@
   }
 
   td {
-    background-color: $green-400;
+    background-color: $neutral-550;
     border-bottom: $standard-light-border;
   }
 

--- a/sass/vars/_color-palette.scss
+++ b/sass/vars/_color-palette.scss
@@ -32,6 +32,7 @@ $neutral-400: #8e8e8e;
 $neutral-500: #c9c9c9;
 $neutral-525: #cdd5d7;
 $neutral-550: #eee;
+$neutral-575: #fafafa;
 $neutral-600: #fff;
 
 $success-100: $green-300;


### PR DESCRIPTION
Change the background color of standard tables to better accommodate various colors of text and iconography

fix #259

Add basic styling for in content tables that have no class attribute.

fix #264

Avoid overlapping text and unwanted overflow with the bulk of tables

fix #259