### PR TITLE
fix: img sizing

### DIFF
--- a/sass/atoms/_base.scss
+++ b/sass/atoms/_base.scss
@@ -10,3 +10,7 @@ body {
   font-size: $base-font-size;
   line-height: $document-line-height;
 }
+
+img {
+  height: auto;
+}


### PR DESCRIPTION
Avoid img scaling issues by adding `height: auto;` to `_base.scss`

fix #278