### PR TITLE
fix: no-slab h3 callouts

### DIFF
--- a/sass/atoms/_callout.scss
+++ b/sass/atoms/_callout.scss
@@ -10,6 +10,11 @@
     @include readable-line-length();
   }
 
+  h3 {
+    background-color: transparent;
+    color: $neutral-100;
+  }
+
   .button {
     max-width: inherit;
     width: 100%;


### PR DESCRIPTION
Use Zilla for h3 heading in callouts but without the background slab

fix #277