### PR TITLE
fix: inline notecards should use normal font-weight

### DIFF
--- a/sass/atoms/_notecards.scss
+++ b/sass/atoms/_notecards.scss
@@ -42,6 +42,7 @@
   }
 
   &.inline {
+    font-weight: normal;
     margin: $base-spacing / 4;
     padding: ($base-spacing / 8) ($base-spacing / 4);
 


### PR DESCRIPTION
Use `font-weight: normal;` for inline notecards

fix #269