### PR TITLE
fix: code element in tables

### DIFF
--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -11,6 +11,10 @@ table {
     padding: $base-spacing / 2;
     text-align: left;
   }
+
+  pre {
+    background-color: $neutral-600;
+  }
 }
 
 /* 


### PR DESCRIPTION
Set background color for `pre` elements inside a `table` element to white

fix #268