### PR TITLE
fix: move pre styling to minimalist

### DIFF
--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -1,3 +1,13 @@
+pre {
+  background-color: $neutral-550;
+  border-left: $code-example-border;
+  line-height: $code-example-line-height;
+  max-width: 100%;
+  overflow: auto;
+  padding: $base-spacing;
+  width: 100%;
+}
+
 code {
   background-color: $neutral-550;
   box-decoration-break: clone;


### PR DESCRIPTION
It makes more sense for the general styling of `pre` elements to live alongside custom styles such as "good" and "bad" variants.

fix #294