### PR TITLE
fix: font size for code examples

### DIFF
--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -1,6 +1,7 @@
 pre {
   background-color: $neutral-550;
   border-left: $code-example-border;
+  font-size: $code-base-font-size;
   line-height: $code-example-line-height;
   max-width: 100%;
   overflow: auto;

--- a/sass/vars/_typography.scss
+++ b/sass/vars/_typography.scss
@@ -5,6 +5,7 @@ $site-font-family-fallback: x-locale-body, sans-serif;
 $site-font-family: arial, $site-font-family-fallback;
 
 $code-inline-font-family: consolas, "Liberation Mono", courier, monospace;
+$code-base-font-size: 1rem;
 
 $base-font-size: 100%;
 $document-line-height: 1.6;


### PR DESCRIPTION
Explicitly set the font size for code example to ensure it is always rendered at a minimum of `1rem`

fix #299