### PR TITLE
fix: change top margin for notecards

### DIFF
--- a/sass/atoms/_notecards.scss
+++ b/sass/atoms/_notecards.scss
@@ -1,6 +1,6 @@
 .notecard {
   border-left: $notecard-border;
-  margin: $base-spacing 0;
+  margin: ($base-spacing / 2) 0 $base-spacing;
   padding: ($base-spacing / 4) ($base-spacing / 2);
 
   &::before {


### PR DESCRIPTION
To better accomodate cases where a notecard is the first item in an article, we
set the top margin to `$base-spacing / 2`

fix #303