### PR TITLE
fix: add bottom margin to tables

### DIFF
--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -25,6 +25,7 @@ table,
 .standard-table,
 .properties {
   border-collapse: collapse;
+  margin-bottom: $base-spacing;
 
   a {
     color: $neutral-100;


### PR DESCRIPTION
To accomodate a recent change with regards to margins in articles,
we need to add a bottom margin to tables.

fix #305