### PR TITLE
fix: improved link color

### DIFF
--- a/sass/atoms/_links.scss
+++ b/sass/atoms/_links.scss
@@ -7,6 +7,10 @@ a {
     text-decoration: underline;
   }
 
+  code {
+    text-decoration-skip-ink: none;
+  }
+
   &.external {
     &::before {
       background: transparent url("~@mdn/dinocons/general/external.svg") 0 0

--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -27,10 +27,6 @@ table,
   border-collapse: collapse;
   margin-bottom: $base-spacing;
 
-  a {
-    color: $neutral-100;
-  }
-
   code {
     background-color: transparent;
     hyphens: auto;

--- a/sass/vars/_color-palette.scss
+++ b/sass/vars/_color-palette.scss
@@ -50,7 +50,7 @@ $error-300: $red-100;
 
 $text-color: $neutral-100;
 $text-color-inverted: $neutral-600;
-$link-color: $primary-200;
+$link-color: $primary-50;
 
 /* Gradients */
 $standard-gradient: linear-gradient(to right, $primary-300, $green-400);


### PR DESCRIPTION
Use `primary-50` for _all_ links. Better contrast, better legibility, more consistency

fix #313