### PR TITLE
Update yarn copy to make public directory if it does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:sass": "sass ./sass/mdn-minimalist.scss ./public/css/main.css",
     "build:sass:watch": "sass ./sass/mdn-minimalist.scss ./public/css/main.css --watch",
     "build:sass:variables": "sass ./sass/shared-variables.module.scss ./public/css/shared-variables.module.css",
-    "copy": "cp -R ./typography ./public/typography",
+    "copy": "mkdir -p ./public && cp -R ./typography ./public/typography",
     "lint": "stylelint sass/**/*.scss",
     "precommit": "yarn run prettier:staged",
     "prettier:check": "prettier --check **/*.scss",


### PR DESCRIPTION
When I tried to run the project for the first time I didn't have a public folder so the copy command failed. So I have updated the yarn copy command to make a public directory if it doesn't exist. :)