### PR TITLE
fix: highlighted link state

### DIFF
--- a/sass/mixins/_links.scss
+++ b/sass/mixins/_links.scss
@@ -1,4 +1,4 @@
 @mixin highlighted-link-state() {
-  background-color: $primary-200;
+  background-color: $primary-50;
   color: $text-color-inverted;
 }

--- a/test/sass/_test-mixins-links.scss
+++ b/test/sass/_test-mixins-links.scss
@@ -6,7 +6,7 @@
       }
 
       @include expect {
-        background-color: #1e7f9d;
+        background-color: #00458b;
         color: #fff;
       }
     }


### PR DESCRIPTION
Update background color for `highlighted-link-state` to `$primary-50`

fix #317
