### PR TITLE
fix: prism theme update

### DIFF
--- a/sass/atoms/_primsjs.scss
+++ b/sass/atoms/_primsjs.scss
@@ -17,6 +17,7 @@
 .language-css .token.string,
 .style .token.string,
 .token.variable {
+  background-color: transparent;
   color: $neutral-100;
 }
 


### PR DESCRIPTION
Updates the operator, entity etc. selectors to have a transparent background style

fix #342
