### PR TITLE
fix: remove missed top margins

### DIFF
--- a/sass/atoms/_examples.scss
+++ b/sass/atoms/_examples.scss
@@ -1,7 +1,8 @@
 .sample-code-frame {
   border: $thin-primary-border;
   border-left: $code-example-border;
-  margin: ($base-spacing / 2) 0;
+  margin: 0;
+  margin-bottom: ($base-spacing / 2);
   padding: 0 ($base-spacing / 2);
   width: 100%;
 }

--- a/sass/atoms/_notecards.scss
+++ b/sass/atoms/_notecards.scss
@@ -1,6 +1,7 @@
 .notecard {
   border-left: $notecard-border;
-  margin: ($base-spacing / 2) 0 $base-spacing;
+  margin: 0;
+  margin-bottom: $base-spacing;
   padding: ($base-spacing / 2);
 
   a {


### PR DESCRIPTION
removes top margins from examples and notecards
