### PR TITLE
fix: readable line length

### DIFF
--- a/sass/mixins/_typography.scss
+++ b/sass/mixins/_typography.scss
@@ -48,6 +48,7 @@
 }
 
 @mixin blockquote() {
+  @include readable-line-length();
   font-size: $small-medium-font-size-mobile;
 
   @media #{$mq-tablet-and-up} {

--- a/sass/mixins/_utils.scss
+++ b/sass/mixins/_utils.scss
@@ -12,7 +12,7 @@
  */
 @mixin readable-line-length() {
   max-width: $max-line-length;
-  max-width: 80ch;
+  max-width: 75ch;
 }
 
 /* 

--- a/test/sass/_test-mixins-utils.scss
+++ b/test/sass/_test-mixins-utils.scss
@@ -37,7 +37,7 @@
 
       @include expect {
         max-width: 42rem;
-        max-width: 80ch;
+        max-width: 75ch;
       }
     }
   }


### PR DESCRIPTION
Bump down `readable-line-length` to `75ch` and also apply to `blockquote` elements

fix #375
