### PR TITLE
chore: Allow Dependabot bumps for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 99


### PR DESCRIPTION
There are a few actions that are still on v1 versions, so I figure this is a simpler way to get them back up-to-date