### PR TITLE
Add `white-space: nowrap` to kbd element

### DIFF
--- a/sass/atoms/_kbd.scss
+++ b/sass/atoms/_kbd.scss
@@ -11,6 +11,7 @@ kbd {
   line-height: 1;
   margin: $base-unit / 2;
   padding: ($base-spacing / 6) ($base-spacing / 4);
+  white-space: nowrap;
 }
 
 /*


### PR DESCRIPTION
Without `white-space: nowrap`:

![image](https://user-images.githubusercontent.com/2025661/103498071-7b839980-4e7e-11eb-8db3-2a4b0a00cf20.png)

With `white-space: nowrap`:

![image](https://user-images.githubusercontent.com/2025661/103498126-a4a42a00-4e7e-11eb-8d56-1f76de1bef1d.png)
