### PR TITLE
fix: update same-code-frame style

### DIFF
--- a/sass/atoms/_examples.scss
+++ b/sass/atoms/_examples.scss
@@ -1,8 +1,9 @@
 .sample-code-frame {
   border: $thin-primary-border;
   border-left: $code-example-border;
+  height: auto;
   margin: 0;
   margin-bottom: ($base-spacing / 2);
-  padding: 0 ($base-spacing / 2);
+  padding: ($base-spacing / 2);
   width: 100%;
 }


### PR DESCRIPTION
Update `padding` and `height` for `sample-code-frame` blocks

fix #422
