### PR TITLE
fix: page overlay stacking order

### DIFF
--- a/sass/atoms/_overlays.scss
+++ b/sass/atoms/_overlays.scss
@@ -7,8 +7,8 @@
   left: 0;
   position: fixed;
   right: 0;
-  /* This is to accomodate for the page header on all viewports */
+  /* This is to accommodate for the page header on all viewports */
   top: 90px;
   width: 100%;
-  z-index: $middle-layer;
+  z-index: $top-layer;
 }


### PR DESCRIPTION
Bump up the `z-index` of the `page-overlay` to `top-layer`.

fix #427
