### PR TITLE
feat: add slab-highlight mixin

### DIFF
--- a/sass/atoms/_typography.scss
+++ b/sass/atoms/_typography.scss
@@ -33,12 +33,9 @@ h2 {
 
 h3 {
   @include heading-3();
-  background-color: $neutral-100;
-  color: $text-color-inverted;
-  font-weight: normal;
+  @include slab-highlight();
+
   margin: $base-spacing 0;
-  max-width: max-content;
-  padding: 0 $base-unit;
 }
 
 h4 {

--- a/sass/mixins/_typography.scss
+++ b/sass/mixins/_typography.scss
@@ -60,3 +60,11 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+@mixin slab-highlight() {
+  background-color: $neutral-100;
+  color: $text-color-inverted;
+  font-weight: normal;
+  max-width: max-content;
+  padding: 0 $base-unit;
+}

--- a/test/sass/_test-mixins-typography.scss
+++ b/test/sass/_test-mixins-typography.scss
@@ -41,3 +41,21 @@
     }
   }
 }
+
+@include describe("slab-highlight") {
+  @include it("Returns ZillaSlab Highlight style") {
+    @include assert {
+      @include output {
+        @include slab-highlight();
+      }
+
+      @include expect {
+        background-color: #212121;
+        color: #fff;
+        font-weight: normal;
+        max-width: max-content;
+        padding: 0 6px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add `slab-highlight` mixin to `typography` to allow `h3` style styling for other elements.

fix #437
