### PR TITLE
don't get height on .sample-code-frame

### DIFF
--- a/sass/atoms/_examples.scss
+++ b/sass/atoms/_examples.scss
@@ -1,7 +1,6 @@
 .sample-code-frame {
   border: $thin-primary-border;
   border-left: $code-example-border;
-  height: auto;
   margin: 0;
   margin-bottom: ($base-spacing / 2);
   padding: ($base-spacing / 2);


### PR DESCRIPTION
A partial solution to https://github.com/mdn/yari/issues/2683

This essentially reverts https://github.com/mdn/mdn-minimalist/pull/423

I tested this by editing the file `node_modules/@mdn/minimalist/sass/atoms/_examples.scss` in my `yari` repo and then I visited a bunch of pages that have `EmbedLiveSample`. Including

* http://localhost:3000/en-US/docs/Web/CSS/CSS_Background_and_Borders/Box-shadow_generator
* http://localhost:3000/en-US/docs/Web/SVG/Attribute/y2
* http://localhost:3000/en-US/docs/Web/SVG/Tutorial/Patterns
* http://localhost:3000/en-US/docs/Web/SVG/Attribute/vector-effect
* http://localhost:3000/en-US/docs/web/html/element/input/submit
