### PR TITLE
fix: wider readable line length

### DIFF
--- a/sass/mixins/_utils.scss
+++ b/sass/mixins/_utils.scss
@@ -11,8 +11,8 @@
  * width to what is commonly known to be a readable line length for prose.
  */
 @mixin readable-line-length() {
-  max-width: $max-line-length;
-  max-width: 75ch;
+  max-width: $max-line-length-fallback;
+  max-width: 85ch;
 }
 
 /* 

--- a/sass/vars/_typography.scss
+++ b/sass/vars/_typography.scss
@@ -36,4 +36,4 @@ $small-font-size: 0.9rem; /* 16px */
 $tiny-text: 0.75rem; /* 13.5px */
 
 /* approx 72ch for base font size and HHGTTG reference */
-$max-line-length: 42rem;
+$max-line-length-fallback: 45rem;

--- a/test/sass/_test-mixins-utils.scss
+++ b/test/sass/_test-mixins-utils.scss
@@ -36,8 +36,8 @@
       }
 
       @include expect {
-        max-width: 42rem;
-        max-width: 75ch;
+        max-width: 45rem;
+        max-width: 85ch;
       }
     }
   }


### PR DESCRIPTION
Enable a wider default readable line length. From 75ch to 85ch

fix #457
