### PR TITLE
fix: highlighted link state

### DIFF
--- a/sass/atoms/_links.scss
+++ b/sass/atoms/_links.scss
@@ -32,5 +32,5 @@ a {
  * to avoid unnecessary code duplication
  */
 .highlighted-link-state {
-  @highlighted-link-state();
+  @include highlighted-link-state();
 }


### PR DESCRIPTION
Ensure that the class `highlighted-link-state` correctly uses the mixin

fix #488
