### PR TITLE
fix: remove spec badges

### DIFF
--- a/sass/atoms/_meta.scss
+++ b/sass/atoms/_meta.scss
@@ -26,108 +26,25 @@
 }
 
 /* Specification badges */
-.spec-cr,
-.spec-ed,
-.spec-draft,
-.spec-lc,
-.spec-living,
-.spec-obsolete,
-.spec-pr,
-.spec-rec,
-.spec-rfc,
-.spec-standard,
-.spec-wd {
-  &::before {
-    background-color: $neutral-575;
-    border-left: 5px solid $neutral-100;
-    border-radius: 6px;
-    display: inline-block;
-    margin-right: $base-spacing / 4;
-    padding: $base-spacing / 4;
-  }
-}
-
 .spec-living,
 .spec-standard {
   color: $primary-50;
-
-  &::before {
-    border-color: $primary-50;
-    content: "LS";
-  }
-}
-
-.spec-standard {
-  &::before {
-    content: "ST";
-  }
 }
 
 .spec-cr,
 .spec-pr,
 .spec-rec,
 .spec-rfc {
-  color: $green-200;
-
-  &::before {
-    border-color: $green-100;
-    content: "REC";
-  }
-}
-
-.spec-cr {
-  &::before {
-    content: "CR";
-  }
-}
-
-.spec-pr {
-  &::before {
-    content: "PR";
-  }
-}
-
-.spec-rfc {
-  &::before {
-    content: "RFC";
-  }
+  color: $green-100;
 }
 
 .spec-draft,
 .spec-lc,
 .spec-wd {
-  color: $orange-300;
-
-  &::before {
-    border-color: $orange-300;
-    content: "WD";
-  }
-}
-
-.spec-draft {
-  &::before {
-    content: "D";
-  }
-}
-
-.spec-lc {
-  &::before {
-    content: "LC";
-  }
+  color: $orange-100;
 }
 
 .spec-ed,
 .spec-obsolete {
-  color: $red-200;
-
-  &::before {
-    border-color: $red-200;
-    content: "ED";
-  }
-}
-
-.spec-obsolete {
-  &::before {
-    content: "O";
-  }
+  color: $red-100;
 }


### PR DESCRIPTION
Remove spec badges that are added using CSS psuedo elements and only keep the text color.
Improve colour constrast for the draft and obsolete spec text.

Fix #516
