### PR TITLE
fix: move external icon to right

### DIFF
--- a/sass/atoms/_links.scss
+++ b/sass/atoms/_links.scss
@@ -12,14 +12,14 @@ a {
   }
 
   &.external {
-    &::before {
+    &::after {
       background: transparent url("~@mdn/dinocons/general/external.svg") 0 0
         no-repeat;
       background-size: 16px;
       content: "";
       display: inline-block;
       height: 16px;
-      margin-right: $base-spacing / 8;
+      margin-left: $base-spacing / 8;
       width: 16px;
     }
   }


### PR DESCRIPTION
Move the external icon to the right hand side of the link

Fix #462
