### PR TITLE
fix: slab-highlight should set font-family

### DIFF
--- a/sass/atoms/_typography.scss
+++ b/sass/atoms/_typography.scss
@@ -58,6 +58,10 @@ p {
   font-size: $tiny-text;
 }
 
+.slab-highlight {
+  @include slab-highlight();
+}
+
 .readable-line-length {
   @include readable-line-length();
 }

--- a/sass/mixins/_typography.scss
+++ b/sass/mixins/_typography.scss
@@ -64,6 +64,7 @@
 @mixin slab-highlight() {
   background-color: $neutral-100;
   color: $text-color-inverted;
+  font-family: $heading-font-family;
   font-weight: normal;
   max-width: max-content;
   padding: 0 $base-unit;

--- a/test/sass/_test-mixins-typography.scss
+++ b/test/sass/_test-mixins-typography.scss
@@ -52,6 +52,7 @@
       @include expect {
         background-color: #212121;
         color: #fff;
+        font-family: zillaslab, palatino, "Palatino Linotype", serif;
         font-weight: normal;
         max-width: max-content;
         padding: 0 6px;


### PR DESCRIPTION
When using either the `slab-highlight` mixin or utility class, it should set the
font family to Zilla

Fix #529
