### PR TITLE
fix: correct font color for ghost button

### DIFF
--- a/sass/atoms/_buttons-ghost.scss
+++ b/sass/atoms/_buttons-ghost.scss
@@ -2,6 +2,7 @@
 .ghost {
   background: none;
   border: 0;
+  color: $primary-50;
   cursor: pointer;
   text-decoration: underline;
 


### PR DESCRIPTION
The ghost button font color should be primary-50
