### PR TITLE
fix: properties table width on tablet

### DIFF
--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -42,6 +42,7 @@ table,
   @include readable-line-length();
   border: $standard-primary-border;
   border-left: $property-table-border;
+  width: 100%;
 
   th,
   td {

--- a/styleguide/content/_index.md
+++ b/styleguide/content/_index.md
@@ -6,3 +6,5 @@ home:
   heading: MDN Minimalist
   lead: The base Sass for Mozilla Developer based projects and products
 ---
+
+Contribute to [minimalist on Github](https://github.com/mdn/mdn-minimalist).

--- a/styleguide/layouts/index.html
+++ b/styleguide/layouts/index.html
@@ -3,5 +3,6 @@
     <h1>{{ .Params.home.heading }}</h1>
     <p class="lead">{{ .Params.home.lead }}</p>
     {{- partial "main-nav.html" . -}}
+    {{.Content}}
 </main>
 {{ end }}


### PR DESCRIPTION
Give the `properties` table a base width of 100%

fix #589
