### PR TITLE
No wrapping of inline code elements

### DIFF
--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -6,12 +6,17 @@ code {
   font-family: $code-inline-font-family;
   padding: 0 math.div($base-unit, 2);
   word-wrap: break-word;
+  white-space: nowrap;
 }
 
 .notranslate {
   code {
     background-color: transparent;
   }
+}
+
+.pre {
+  white-space: pre;
 }
 
 .example-bad {

--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -9,14 +9,14 @@ code {
   word-wrap: break-word;
 }
 
+pre code {
+  white-space: pre;
+}
+
 .notranslate {
   code {
     background-color: transparent;
   }
-}
-
-pre code {
-  white-space: pre;
 }
 
 .example-bad {

--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -15,7 +15,7 @@ code {
   }
 }
 
-.pre code {
+pre code {
   white-space: pre;
 }
 

--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -15,7 +15,7 @@ code {
   }
 }
 
-.pre {
+.pre code {
   white-space: pre;
 }
 

--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -5,8 +5,8 @@ code {
   box-decoration-break: clone;
   font-family: $code-inline-font-family;
   padding: 0 math.div($base-unit, 2);
-  word-wrap: break-word;
   white-space: nowrap;
+  word-wrap: break-word;
 }
 
 .notranslate {


### PR DESCRIPTION
Hey Schalk,

it turned out a tad more complicated than I described in Slack. Namely wrapping needs to be (re-)enabled for `code` that is nested inside of a `pre` aka a lot of our code blocks.

Hope the way I did it makes sense, lmk if not!