### PR TITLE
Make example-bad/good pairing colorblind-friendly

### DIFF
--- a/sass/atoms/_code.scss
+++ b/sass/atoms/_code.scss
@@ -17,6 +17,7 @@ code {
 .example-bad {
   background-color: $red-450;
   border-color: $red-300;
+  text-decoration: rgba(100, 100, 100, 0.25) line-through;
 }
 
 .example-good {


### PR DESCRIPTION
Pages like https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Unexpected_token#expression_expected contain pairs of `example-bad` and `example-good`. Using color alone, the distinction may be unclear for some low-color vision readers. This is less a genuine proposal so much as a placeholder for saying we probably ought to use something apart from color to signal to readers that `example-bad` entries shouldn't be used.