### PR TITLE
Prevent the external.svg icon to be separated from the link

### DIFF
--- a/sass/atoms/_links.scss
+++ b/sass/atoms/_links.scss
@@ -15,7 +15,6 @@ a {
 
   &.external {
     display: inline-block;
-    
     &::after {
       background: transparent url("~@mdn/dinocons/general/external.svg") 0 0
         no-repeat;

--- a/sass/atoms/_links.scss
+++ b/sass/atoms/_links.scss
@@ -15,6 +15,7 @@ a {
 
   &.external {
     display: inline-block;
+
     &::after {
       background: transparent url("~@mdn/dinocons/general/external.svg") 0 0
         no-repeat;

--- a/sass/atoms/_links.scss
+++ b/sass/atoms/_links.scss
@@ -14,6 +14,8 @@ a {
   }
 
   &.external {
+    display: inline-block;
+    
     &::after {
       background: transparent url("~@mdn/dinocons/general/external.svg") 0 0
         no-repeat;


### PR DESCRIPTION
Fix #653.

(@schalkneethling : this is my first PR here, so it is probably not good, but let's try 😄  )