### PR TITLE
Multi-line code snippets within tables are failing contrast ratio checks for WCAG AA and AAA

### DIFF
--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -43,7 +43,7 @@ table {
   }
 
   pre {
-    background-color: $mdn-neutral600;
+    background-color: $lightgray;
   }
 
   caption {

--- a/sass/vars/_mdn-web-docs-palette.scss
+++ b/sass/vars/_mdn-web-docs-palette.scss
@@ -1,6 +1,7 @@
 /* mdn color palette v2 */
 $black: #000;
 $white: #fff;
+$lightgray: #eee;
 
 $mdn-neutral100: #f4f4f4;
 $mdn-neutral200: #d5d5d5;


### PR DESCRIPTION
Fixes [#4254](https://github.com/mdn/yari/issues/4254) in `mdn/yari`