### PR TITLE
Adjust the <blockquote> font size

### DIFF
--- a/sass/atoms/_blockquote.scss
+++ b/sass/atoms/_blockquote.scss
@@ -2,7 +2,7 @@
 
 blockquote {
   @include blockquote();
-  font-family: $heading-font-family;
+  font-family: inherit;
   font-weight: normal;
   margin-bottom: $base-spacing;
 

--- a/sass/mixins/_typography.scss
+++ b/sass/mixins/_typography.scss
@@ -55,10 +55,10 @@
 
 @mixin blockquote() {
   @include readable-line-length();
-  font-size: $small-medium-font-size-mobile;
+  font-size: inherit;
 
   @media #{$mq-tablet-and-up} {
-    font-size: $small-medium-font-size;
+    font-size: inherit;
   }
 }
 


### PR DESCRIPTION
To my eye at least, the current 1.25rem (desktop) and 1.125rem (mobile) font size for `<blockquote>` looks much too big — to the point of being distracting/jarring/obtrusive to readability.

I personally have found the `<blockquote>` rendering so distracting/jarring that up until now when creating MDN content, I’ve completely avoided using `<blockquote>` at all.

But now that we’re moving to Markdown, I think we’ll have a lot of contributors marking up content with "`> `" — because I think it’s relatively much more common to use in Markdown sources than `<blockquote>` is in HTML sources. And because of that, I think it’s important that we move to having `<blockquote>` content rendered in a font size that doesn’t risk being distracting and jarring to readers.

So this PR is just a strawman attempt at proposing a concrete change. As-is, it just brings the `<blockquote>` font size down to the baseline of being the same font size as the rest of the content, and doesn’t change anything else. But I am not at all wedded to this change as-is. I’m not a designer or frontend expert, so I defer completely to those who know much better than me about the factors involved and choices that need to be made.

My only request is that we please consider a way to end up with some rendering for `<blockquote>` that doesn’t have it in quite so large a font size.