### PR TITLE
fix: switch ref to main branch

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,6 @@ on: [pull_request_target]
 
 jobs:
   auto-merge:
-    uses: mdn/workflows/.github/workflows/auto-merge.yml@v1
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
     secrets:
       github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/idle-issues-pr.yml
+++ b/.github/workflows/idle-issues-pr.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   idle-issues-prs:
-    uses: mdn/workflows/.github/workflows/idle-issues.yml@v1
+    uses: mdn/workflows/.github/workflows/idle-issues.yml@main


### PR DESCRIPTION
Switch the `ref` part of the workflow string to reference the `main` branch